### PR TITLE
Extract Types into Separate Packages for Frontend and Backends

### DIFF
--- a/internal/api/deepseek/v1/types.go
+++ b/internal/api/deepseek/v1/types.go
@@ -1,0 +1,66 @@
+package deepseek
+
+// Request represents a request to the DeepSeek API
+type Request struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Stream      bool      `json:"stream"`
+	Temperature float64   `json:"temperature,omitempty"`
+	MaxTokens   int       `json:"max_tokens,omitempty"`
+	Tools       []Tool    `json:"tools,omitempty"`
+	ToolChoice  string    `json:"tool_choice,omitempty"`
+}
+
+// Message represents a chat message in DeepSeek format
+type Message struct {
+	Role       string     `json:"role"`
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Name       string     `json:"name,omitempty"`
+}
+
+// This is duplicate of openai.Function, but we should keep it here to avoid circular dependency
+type Function struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Parameters  any    `json:"parameters"`
+}
+
+// This is duplicate of openai.Tool, but we should keep it here to avoid circular dependency
+type Tool struct {
+	Type     string   `json:"type"`
+	Function Function `json:"function"`
+}
+
+type ToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function ToolCallFunction `json:"function"`
+}
+
+type ToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type Response struct {
+	ID      string   `json:"id"`
+	Object  string   `json:"object"`
+	Created int64    `json:"created"`
+	Model   string   `json:"model"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type Choice struct {
+	Index        int     `json:"index"`
+	Message      Message `json:"message"`
+	FinishReason string  `json:"finish_reason"`
+}

--- a/internal/api/ollama/v1/types.go
+++ b/internal/api/ollama/v1/types.go
@@ -1,0 +1,27 @@
+package ollama
+
+// Request represents a request to the Ollama API
+type Request struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Stream      bool      `json:"stream"`
+	Temperature float64   `json:"temperature,omitempty"`
+	MaxTokens   int       `json:"max_tokens,omitempty"`
+}
+
+// Response represents a response from the Ollama API
+type Response struct {
+	Model     string `json:"model"`
+	CreatedAt string `json:"created_at"`
+	Message   struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	} `json:"message"`
+	Done bool `json:"done"`
+}
+
+// Message represents a chat message in Ollama format
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}

--- a/internal/api/ollama/v1/types.go
+++ b/internal/api/ollama/v1/types.go
@@ -11,13 +11,10 @@ type Request struct {
 
 // Response represents a response from the Ollama API
 type Response struct {
-	Model     string `json:"model"`
-	CreatedAt string `json:"created_at"`
-	Message   struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
-	} `json:"message"`
-	Done bool `json:"done"`
+	Model     string  `json:"model"`
+	CreatedAt string  `json:"created_at"`
+	Message   Message `json:"message"`
+	Done      bool    `json:"done"`
 }
 
 // Message represents a chat message in Ollama format

--- a/internal/api/openai/v1/types.go
+++ b/internal/api/openai/v1/types.go
@@ -1,5 +1,10 @@
 package v1
 
+import (
+	"encoding/json"
+	"log"
+)
+
 // ChatCompletionRequest represents an OpenAI-compatible chat completion request
 type ChatCompletionRequest struct {
 	Model       string     `json:"model"`
@@ -10,15 +15,6 @@ type ChatCompletionRequest struct {
 	Functions   []Function `json:"functions,omitempty"`
 	Tools       []Tool     `json:"tools,omitempty"`
 	ToolChoice  any        `json:"tool_choice,omitempty"`
-}
-
-// Message represents a chat message
-type Message struct {
-	Role       string     `json:"role"`
-	Content    string     `json:"content"`
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string     `json:"tool_call_id,omitempty"`
-	Name       string     `json:"name,omitempty"`
 }
 
 // Function represents a callable function
@@ -56,6 +52,15 @@ type ChatCompletionResponse struct {
 	Usage   Usage    `json:"usage"`
 }
 
+// ChatCompletionStreamResponse represents a chat completion streaming response
+type ChatCompletionStreamResponse struct {
+	ID      string         `json:"id"`
+	Object  string         `json:"object"`
+	Created int64          `json:"created"`
+	Model   string         `json:"model"`
+	Choices []StreamChoice `json:"choices"`
+	Usage   Usage          `json:"usage"`
+}
 type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
@@ -78,8 +83,65 @@ type StreamChoice struct {
 
 // Delta represents a streaming response delta
 type Delta struct {
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
+	Role string `json:"role,omitempty"`
+	// Stealing this convention from protobuf because it's what I know,
+	// but it could probably be improved.
+	// Types that are valid to be assigned to Content:
+	// - *Content_String
+	// - *Content_Array
+	Content isContent `json:"content"`
+}
+
+func (d *Delta) MarshalJSON() ([]byte, error) {
+
+	msgMap := map[string]interface{}{
+		"role": d.Role,
+	}
+
+	switch d.Content.(type) {
+	case Content_String:
+		msgMap["content"] = d.Content.(Content_String).Content
+	case Content_Array:
+		msgMap["content"] = d.Content.(Content_Array)
+	}
+
+	return json.Marshal(msgMap)
+}
+func (d *Delta) UnmarshalJSON(data []byte) error {
+	var err error
+	var msg map[string]interface{}
+	if err = json.Unmarshal(data, &msg); err != nil {
+		return err
+	}
+
+	if msg["role"] != nil {
+		d.Role = msg["role"].(string)
+	}
+
+	if msg["content"] != nil {
+		switch msg["content"].(type) {
+		case string:
+			d.Content = Content_String{Content: msg["content"].(string)}
+		case []interface{}:
+			contentArray := msg["content"].([]interface{})
+			contentArrayParts := make(Content_Array, len(contentArray))
+			for i, contentPart := range contentArray {
+				switch val := contentPart.(type) {
+				case map[string]interface{}:
+					if val["type"] == "text" {
+						contentArrayParts[i] = ContentPart_Text{Type: "text", Text: val["text"].(string)}
+					} else {
+						log.Printf("Unknown content part type: %s", val["type"])
+					}
+				default:
+					log.Printf("Unknown content part type: %T", val)
+				}
+			}
+			d.Content = contentArrayParts
+		}
+	}
+
+	return nil
 }
 
 // Models response structure
@@ -93,4 +155,173 @@ type Model struct {
 	Object  string `json:"object"`
 	Created int64  `json:"created"`
 	OwnedBy string `json:"owned_by"`
+}
+
+// Message represents a chat message
+type Message struct {
+	Role string `json:"role"`
+	// Stealing this convention from protobuf because it's what I know,
+	// but it could probably be improved.
+	// Types that are valid to be assigned to Content:
+	// - *Content_String
+	// - *Content_Array
+	Content    isContent  `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Name       string     `json:"name,omitempty"`
+}
+
+func (m *Message) MarshalJSON() ([]byte, error) {
+	toolCallsBytes, err := json.Marshal(m.ToolCalls)
+	if err != nil {
+		return nil, err
+	}
+
+	toolCallsIface := []interface{}{}
+	if err := json.Unmarshal(toolCallsBytes, &toolCallsIface); err != nil {
+		return nil, err
+	}
+
+	msgMap := map[string]interface{}{
+		"role":         m.Role,
+		"tool_calls":   toolCallsIface,
+		"tool_call_id": m.ToolCallID,
+		"name":         m.Name,
+	}
+
+	switch m.Content.(type) {
+	case Content_String:
+		msgMap["content"] = m.Content.(Content_String).Content
+	case Content_Array:
+		msgMap["content"] = m.Content.(Content_Array)
+	}
+
+	return json.Marshal(msgMap)
+}
+func (m *Message) UnmarshalJSON(data []byte) error {
+	var err error
+	var msg map[string]interface{}
+	if err = json.Unmarshal(data, &msg); err != nil {
+		return err
+	}
+
+	if msg["role"] != nil {
+		m.Role = msg["role"].(string)
+	}
+
+	if msg["content"] != nil {
+		switch msg["content"].(type) {
+		case string:
+			m.Content = Content_String{Content: msg["content"].(string)}
+		case []interface{}:
+			contentArray := msg["content"].([]interface{})
+			contentArrayParts := make(Content_Array, len(contentArray))
+			for i, contentPart := range contentArray {
+				switch val := contentPart.(type) {
+				case map[string]interface{}:
+					if val["type"] == "text" {
+						contentArrayParts[i] = ContentPart_Text{Type: "text", Text: val["text"].(string)}
+					} else {
+						log.Printf("Unknown content part type: %s", val["type"])
+					}
+				default:
+					log.Printf("Unknown content part type: %T", val)
+				}
+			}
+			m.Content = contentArrayParts
+		}
+	}
+
+	if msg["tool_calls"] != nil {
+		var toolCalls []ToolCall
+		if toolCallsInterface, ok := msg["tool_calls"].([]interface{}); ok {
+			for _, toolCall := range toolCallsInterface {
+				toolCallMap := toolCall.(map[string]interface{})
+				toolCalls = append(toolCalls, ToolCall{
+					ID:       toolCallMap["id"].(string),
+					Type:     toolCallMap["type"].(string),
+					Function: ToolCallFunction{Name: toolCallMap["function"].(map[string]interface{})["name"].(string), Arguments: toolCallMap["function"].(map[string]interface{})["arguments"].(string)},
+				})
+			}
+		}
+		m.ToolCalls = toolCalls
+	}
+
+	if msg["tool_call_id"] != nil {
+		m.ToolCallID = msg["tool_call_id"].(string)
+	}
+
+	if msg["name"] != nil {
+		m.Name = msg["name"].(string)
+	}
+
+	return nil
+}
+
+func (m *Message) GetContent() isContent {
+	if m != nil {
+		return m.Content
+	}
+
+	return nil
+}
+
+func (m *Message) GetContentString() string {
+	if m != nil {
+		if c, ok := m.Content.(Content_String); ok {
+			return c.Content
+		}
+	}
+	return ""
+}
+
+func (m *Message) GetContentArray() Content_Array {
+	if m != nil {
+		if c, ok := m.Content.(Content_Array); ok {
+			return c
+		}
+	}
+	return nil
+}
+
+type isContent interface {
+	isContent()
+}
+
+type Content_String struct {
+	Content string
+}
+
+func (c Content_String) isContent() {}
+
+type Content_Array []isContentPart
+
+func (c Content_Array) isContent() {}
+
+// Currently only text is supported
+type isContentPart interface {
+	isContentPart()
+}
+
+type ContentPart_Text struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func (c ContentPart_Text) isContentPart() {}
+
+func (a Content_Array) GetContentPartAtIndex(index int) isContentPart {
+	if len(a) > index && a[index] != nil {
+		return a[index]
+	}
+	return nil
+}
+
+func (a Content_Array) GetContentPartTextAtIndex(index int) *ContentPart_Text {
+	if len(a) > index && a[index] != nil {
+		if cp, ok := a[index].(ContentPart_Text); ok {
+			return &cp
+		}
+	}
+	return nil
 }

--- a/internal/api/openai/v1/types.go
+++ b/internal/api/openai/v1/types.go
@@ -1,0 +1,96 @@
+package v1
+
+// ChatCompletionRequest represents an OpenAI-compatible chat completion request
+type ChatCompletionRequest struct {
+	Model       string     `json:"model"`
+	Messages    []Message  `json:"messages"`
+	Stream      bool       `json:"stream"`
+	Temperature *float64   `json:"temperature,omitempty"`
+	MaxTokens   *int       `json:"max_tokens,omitempty"`
+	Functions   []Function `json:"functions,omitempty"`
+	Tools       []Tool     `json:"tools,omitempty"`
+	ToolChoice  any        `json:"tool_choice,omitempty"`
+}
+
+// Message represents a chat message
+type Message struct {
+	Role       string     `json:"role"`
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Name       string     `json:"name,omitempty"`
+}
+
+// Function represents a callable function
+type Function struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Parameters  any    `json:"parameters"`
+}
+
+// Tool represents an available tool
+type Tool struct {
+	Type     string   `json:"type"`
+	Function Function `json:"function"`
+}
+
+// ToolCall represents a call to a tool
+type ToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function ToolCallFunction `json:"function"`
+}
+
+type ToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// ChatCompletionResponse represents a chat completion response
+type ChatCompletionResponse struct {
+	ID      string   `json:"id"`
+	Object  string   `json:"object"`
+	Created int64    `json:"created"`
+	Model   string   `json:"model"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// Choice represents a completion choice
+type Choice struct {
+	Index        int     `json:"index"`
+	Message      Message `json:"message"`
+	FinishReason string  `json:"finish_reason"`
+}
+
+// StreamChoice represents a streaming completion choice
+type StreamChoice struct {
+	Index        int    `json:"index"`
+	Delta        Delta  `json:"delta"`
+	FinishReason string `json:"finish_reason,omitempty"`
+}
+
+// Delta represents a streaming response delta
+type Delta struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// Models response structure
+type ModelsResponse struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
+type Model struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}

--- a/internal/api/openrouter/v1/types.go
+++ b/internal/api/openrouter/v1/types.go
@@ -1,0 +1,4 @@
+package openrouter
+
+// OpenRouter uses OpenAI-compatible types, so we can reuse those
+// This package exists to document the API and add any OpenRouter-specific extensions

--- a/proxy-ollama.go
+++ b/proxy-ollama.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	ollamaEndpoint = "http://localhost:11434/api"
-	defaultModel   = "llama2"
+	// defaultModel   = "llama2"
+	defaultModel = "deepseek-r1:14b"
 )
 
 // Configuration structure

--- a/proxy-openrouter.go
+++ b/proxy-openrouter.go
@@ -90,9 +90,22 @@ func convertMessages(messages []openai.Message) []deepseek.Message {
 	converted := make([]deepseek.Message, len(messages))
 	for i, msg := range messages {
 		log.Printf("Converting message %d - Role: %s", i, msg.Role)
+		var content string
+		switch msg.GetContent().(type) {
+		case openai.Content_String:
+			content = msg.GetContentString()
+		case openai.Content_Array:
+			contentArray := msg.GetContentArray()
+			for i := range contentArray {
+				t := contentArray.GetContentPartTextAtIndex(i).Text
+				if t != "" {
+					content += "; " + t
+				}
+			}
+		}
 		converted[i] = deepseek.Message{
 			Role:       msg.Role,
-			Content:    msg.Content,
+			Content:    content,
 			ToolCallID: msg.ToolCallID,
 			Name:       msg.Name,
 		}

--- a/proxy-openrouter.go
+++ b/proxy-openrouter.go
@@ -1,683 +1,630 @@
 package main
 
 import (
-        "bufio"
-        "bytes"
-        "compress/flate"
-        "compress/gzip"
-        "context"
-        "encoding/json"
-        "fmt"
-        "io"
-        "log"
-        "net/http"
-        "os"
-        "strings"
-        "time"
+	"bufio"
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
 
-        "github.com/andybalholm/brotli"
-        "github.com/joho/godotenv"
-        "golang.org/x/net/http2"
+	"github.com/andybalholm/brotli"
+	deepseek "github.com/danilofalcao/cursor-deepseek/internal/api/deepseek/v1"
+	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/joho/godotenv"
+	"golang.org/x/net/http2"
 )
 
 const (
-        openRouterEndpoint = "https://openrouter.ai/api/v1"
-        deepseekChatModel = "deepseek/deepseek-chat"
+	openRouterEndpoint = "https://openrouter.ai/api/v1"
+	defaultChatModel   = "deepseek/deepseek-chat"
 )
 
 var openRouterAPIKey string
 
 func init() {
-        // Load .env file
-        if err := godotenv.Load(); err != nil {
-                log.Printf("Warning: .env file not found or error loading it: %v", err)
-        }
+	// Load .env file
+	if err := godotenv.Load(); err != nil {
+		log.Printf("Warning: .env file not found or error loading it: %v", err)
+	}
 
-        // Get OpenRouter API key
-        openRouterAPIKey = os.Getenv("OPENROUTER_API_KEY")
-        if openRouterAPIKey == "" {
-                log.Fatal("OPENROUTER_API_KEY environment variable is required")
-        }
-}
-
-// Models response structure
-type ModelsResponse struct {
-        Object string  `json:"object"`
-        Data   []Model `json:"data"`
-}
-
-type Model struct {
-        ID      string `json:"id"`
-        Object  string `json:"object"`
-        Created int64  `json:"created"`
-        OwnedBy string `json:"owned_by"`
-}
-
-// OpenAI compatible request structure
-type ChatRequest struct {
-        Model       string      `json:"model"`
-        Messages    []Message   `json:"messages"`
-        Stream      bool        `json:"stream"`
-        Functions   []Function  `json:"functions,omitempty"`
-        Tools       []Tool      `json:"tools,omitempty"`
-        ToolChoice  interface{} `json:"tool_choice,omitempty"`
-        Temperature *float64    `json:"temperature,omitempty"`
-        MaxTokens   *int        `json:"max_tokens,omitempty"`
-}
-
-type Message struct {
-        Role       string     `json:"role"`
-        Content    string     `json:"content"`
-        ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
-        ToolCallID string     `json:"tool_call_id,omitempty"`
-        Name       string     `json:"name,omitempty"`
-}
-
-type Function struct {
-        Name        string `json:"name"`
-        Description string `json:"description"`
-        Parameters  any    `json:"parameters"`
-}
-
-type Tool struct {
-        Type     string   `json:"type"`
-        Function Function `json:"function"`
-}
-
-type ToolCall struct {
-        ID       string `json:"id"`
-        Type     string `json:"type"`
-        Function struct {
-                Name      string `json:"name"`
-                Arguments string `json:"arguments"`
-        } `json:"function"`
+	// Get OpenRouter API key
+	openRouterAPIKey = os.Getenv("OPENROUTER_API_KEY")
+	if openRouterAPIKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required")
+	}
 }
 
 func convertToolChoice(choice interface{}) string {
-        if choice == nil {
-                return ""
-        }
+	if choice == nil {
+		return ""
+	}
 
-        // If string "auto" or "none"
-        if str, ok := choice.(string); ok {
-                switch str {
-                case "auto", "none":
-                        return str
-                }
-        }
+	// If string "auto" or "none"
+	if str, ok := choice.(string); ok {
+		switch str {
+		case "auto", "none":
+			return str
+		}
+	}
 
-        // Try to parse as map for function call
-        if choiceMap, ok := choice.(map[string]interface{}); ok {
-                if choiceMap["type"] == "function" {
-                        return "auto" // DeepSeek doesn't support specific function selection, default to auto
-                }
-        }
+	// Try to parse as map for function call
+	if choiceMap, ok := choice.(map[string]interface{}); ok {
+		if choiceMap["type"] == "function" {
+			return "auto" // DeepSeek doesn't support specific function selection, default to auto
+		}
+	}
 
-        return ""
+	return ""
 }
 
-func convertMessages(messages []Message) []Message {
-        converted := make([]Message, len(messages))
-        for i, msg := range messages {
-                log.Printf("Converting message %d - Role: %s", i, msg.Role)
-                converted[i] = msg
+func convertToolCalls(toolCalls []openai.ToolCall, toolType string) []deepseek.ToolCall {
+	getToolType := func(toolCall openai.ToolCall) string {
+		if toolType != "" {
+			return toolType
+		}
+		return toolCall.Type
+	}
+	converted := make([]deepseek.ToolCall, len(toolCalls))
+	for i, tc := range toolCalls {
+		converted[i] = deepseek.ToolCall{
+			ID:   tc.ID,
+			Type: getToolType(tc),
+			Function: deepseek.ToolCallFunction{
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			},
+		}
+	}
+	return converted
+}
 
-                // Convert function role to tool role
-                if msg.Role == "function" {
-                        converted[i].Role = "tool"
-                        log.Printf("Converted function role to tool role")
-                }
+func convertMessages(messages []openai.Message) []deepseek.Message {
+	converted := make([]deepseek.Message, len(messages))
+	for i, msg := range messages {
+		log.Printf("Converting message %d - Role: %s", i, msg.Role)
+		converted[i] = deepseek.Message{
+			Role:       msg.Role,
+			Content:    msg.Content,
+			ToolCallID: msg.ToolCallID,
+			Name:       msg.Name,
+		}
 
-                // Handle assistant messages with tool calls
-                if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-                        log.Printf("Processing assistant message with %d tool calls", len(msg.ToolCalls))
+		// Convert function role to tool role
+		if msg.Role == "function" {
+			converted[i].Role = "tool"
+			converted[i].ToolCalls = convertToolCalls(msg.ToolCalls, "")
+			log.Printf("Converted function role to tool role")
+		}
 
-                        // Ensure tool calls are properly formatted
-                        toolCalls := make([]ToolCall, len(msg.ToolCalls))
-                        for j, tc := range msg.ToolCalls {
-                                toolCalls[j] = ToolCall{
-                                        ID:   tc.ID,
-                                        Type: "function",
-                                        Function: struct {
-                                                Name      string `json:"name"`
-                                                Arguments string `json:"arguments"`
-                                        }{
-                                                Name:      tc.Function.Name,
-                                                Arguments: tc.Function.Arguments,
-                                        },
-                                }
-                                log.Printf("Processed tool call %d - Name: %s", j, tc.Function.Name)
-                        }
-                        converted[i].ToolCalls = toolCalls
-                }
+		// Handle assistant messages with tool calls
+		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			log.Printf("Processing assistant message with %d tool calls", len(msg.ToolCalls))
 
-                // Handle tool response messages
-                if msg.Role == "tool" || msg.Role == "function" {
-                        log.Printf("Processing tool/function response message")
-                        converted[i].Role = "tool"
-                        if msg.Name != "" {
-                                log.Printf("Tool response from function: %s", msg.Name)
-                        }
-                }
-        }
+			// Ensure tool calls are properly formatted
+			converted[i].ToolCalls = convertToolCalls(msg.ToolCalls, "function")
+		}
 
-        return converted
+		// Handle tool response messages
+		if msg.Role == "tool" || msg.Role == "function" {
+			log.Printf("Processing tool/function response message")
+			converted[i].Role = "tool"
+			if msg.Name != "" {
+				log.Printf("Tool response from function: %s", msg.Name)
+			}
+		}
+	}
+
+	return converted
 }
 
 func truncateString(s string, maxLen int) string {
-        if len(s) <= maxLen {
-                return s
-        }
-        return s[:maxLen] + "..."
-}
-
-// DeepSeek request structure
-type DeepSeekRequest struct {
-        Model       string    `json:"model"`
-        Messages    []Message `json:"messages"`
-        Stream      bool      `json:"stream"`
-        Temperature float64   `json:"temperature,omitempty"`
-        MaxTokens   int       `json:"max_tokens,omitempty"`
-        Tools       []Tool    `json:"tools,omitempty"`
-        ToolChoice  string    `json:"tool_choice,omitempty"`
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }
 
 func main() {
-        log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 
-        server := &http.Server{
-                Addr:    ":9000",
-                Handler: http.HandlerFunc(proxyHandler),
-        }
+	server := &http.Server{
+		Addr:    ":9000",
+		Handler: http.HandlerFunc(proxyHandler),
+	}
 
-        // Enable HTTP/2 support
-        http2.ConfigureServer(server, &http2.Server{})
+	// Enable HTTP/2 support
+	http2.ConfigureServer(server, &http2.Server{})
 
-        log.Printf("Starting proxy server on %s", server.Addr)
-        if err := server.ListenAndServe(); err != nil {
-                log.Fatalf("Server failed: %v", err)
-        }
+	log.Printf("Starting proxy server on %s", server.Addr)
+	if err := server.ListenAndServe(); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
 }
 
 func enableCors(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Access-Control-Allow-Origin", "*")
-        w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-        w.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
-        w.Header().Set("Access-Control-Expose-Headers", "Content-Length")
-        w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Length")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }
 
 func proxyHandler(w http.ResponseWriter, r *http.Request) {
-        log.Printf("Received request: %s %s", r.Method, r.URL.Path)
+	log.Printf("Received request: %s %s", r.Method, r.URL.Path)
 
-        if r.Method == "OPTIONS" {
-                enableCors(w, r)
-                return
-        }
+	if r.Method == "OPTIONS" {
+		enableCors(w, r)
+		return
+	}
 
-        enableCors(w, r)
+	enableCors(w, r)
 
-        // Validate API key
-        authHeader := r.Header.Get("Authorization")
-        if !strings.HasPrefix(authHeader, "Bearer ") {
-                log.Printf("Missing or invalid Authorization header")
-                http.Error(w, "Missing or invalid Authorization header", http.StatusUnauthorized)
-                return
-        }
+	// Validate API key
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		log.Printf("Missing or invalid Authorization header")
+		http.Error(w, "Missing or invalid Authorization header", http.StatusUnauthorized)
+		return
+	}
 
-        userAPIKey := strings.TrimPrefix(authHeader, "Bearer ")
-        if userAPIKey != openRouterAPIKey {
-                log.Printf("Invalid API key provided")
-                http.Error(w, "Invalid API key", http.StatusUnauthorized)
-                return
-        }
+	userAPIKey := strings.TrimPrefix(authHeader, "Bearer ")
+	if userAPIKey != openRouterAPIKey {
+		log.Printf("Invalid API key provided")
+		http.Error(w, "Invalid API key", http.StatusUnauthorized)
+		return
+	}
 
-        // Handle /v1/models endpoint
-        if r.URL.Path == "/v1/models" && r.Method == "GET" {
-                log.Printf("Handling /v1/models request")
-                handleModelsRequest(w)
-                return
-        }
+	// Handle /v1/models endpoint
+	if r.URL.Path == "/v1/models" && r.Method == "GET" {
+		log.Printf("Handling /v1/models request")
+		handleModelsRequest(w)
+		return
+	}
 
-        // Log headers for debugging
-        log.Printf("Request headers: %+v", r.Header)
+	// Log headers for debugging
+	log.Printf("Request headers: %+v", r.Header)
 
-        // Only handle chat completions API requests
-        if r.URL.Path != "/v1/chat/completions" {
-                log.Printf("Invalid path: %s", r.URL.Path)
-                http.Error(w, "Only /v1/chat/completions endpoint is supported", http.StatusNotFound)
-                return
-        }
+	// Only handle chat completions API requests
+	if r.URL.Path != "/v1/chat/completions" {
+		log.Printf("Invalid path: %s", r.URL.Path)
+		http.Error(w, "Only /v1/chat/completions endpoint is supported", http.StatusNotFound)
+		return
+	}
 
-        // Read and log request body for debugging
-        var chatReq ChatRequest
-        body, err := io.ReadAll(r.Body)
-        if err != nil {
-                log.Printf("Error reading request body: %v", err)
-                http.Error(w, "Error reading request", http.StatusBadRequest)
-                return
-        }
-        r.Body = io.NopCloser(bytes.NewBuffer(body))
+	// Read and log request body for debugging
+	var chatReq openai.ChatCompletionRequest
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Error reading request body: %v", err)
+		http.Error(w, "Error reading request", http.StatusBadRequest)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
 
-        if err := json.Unmarshal(body, &chatReq); err != nil {
-                log.Printf("Error parsing request JSON: %v", err)
-                log.Printf("Raw request body: %s", string(body))
-                http.Error(w, "Invalid JSON", http.StatusBadRequest)
-                return
-        }
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		log.Printf("Error parsing request JSON: %v", err)
+		log.Printf("Raw request body: %s", string(body))
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
 
-        log.Printf("Parsed request: %+v", chatReq)
+	log.Printf("Parsed request: %+v", chatReq)
 
-        // Handle models endpoint
-        if r.URL.Path == "/v1/models" {
-                handleModelsRequest(w)
-                return
-        }
+	// Handle models endpoint
+	if r.URL.Path == "/v1/models" {
+		handleModelsRequest(w)
+		return
+	}
 
-        // Only handle API requests with /v1/ prefix
-        if !strings.HasPrefix(r.URL.Path, "/v1/") {
-                log.Printf("Invalid path: %s", r.URL.Path)
-                http.Error(w, "Not found", http.StatusNotFound)
-                return
-        }
+	// Only handle API requests with /v1/ prefix
+	if !strings.HasPrefix(r.URL.Path, "/v1/") {
+		log.Printf("Invalid path: %s", r.URL.Path)
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
 
-        // Restore the body for further reading
-        r.Body = io.NopCloser(bytes.NewBuffer(body))
+	// Restore the body for further reading
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
 
-        log.Printf("Request body: %s", string(body))
+	log.Printf("Request body: %s", string(body))
 
-        // Parse the request to check for streaming - reuse existing chatReq
-        if err := json.Unmarshal(body, &chatReq); err != nil {
-                log.Printf("Error parsing request JSON: %v", err)
-                http.Error(w, "Error parsing request", http.StatusBadRequest)
-                return
-        }
+	// Parse the request to check for streaming - reuse existing chatReq
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		log.Printf("Error parsing request JSON: %v", err)
+		http.Error(w, "Error parsing request", http.StatusBadRequest)
+		return
+	}
 
-        log.Printf("Requested model: %s", chatReq.Model)
+	log.Printf("Requested model: %s", chatReq.Model)
 
-        // Store original model name for response
-        originalModel := chatReq.Model
+	// Store original model name for response
+	originalModel := chatReq.Model
 
-        // Convert to deepseek-chat internally
-        chatReq.Model = deepseekChatModel
-        log.Printf("Model converted to: %s (original: %s)", deepseekChatModel, originalModel)
+	// Convert to deepseek-chat internally
+	chatReq.Model = defaultChatModel
+	log.Printf("Model converted to: %s (original: %s)", defaultChatModel, originalModel)
 
-        // Convert to DeepSeek request format
-        deepseekReq := DeepSeekRequest{
-                Model:    deepseekChatModel,
-                Messages: convertMessages(chatReq.Messages),
-                Stream:   chatReq.Stream,
-        }
+	// Convert to DeepSeek request format
+	deepseekReq := deepseek.Request{
+		Model:    defaultChatModel,
+		Messages: convertMessages(chatReq.Messages),
+		Stream:   chatReq.Stream,
+	}
 
-        // Set default temperature if not provided
-        if chatReq.Temperature != nil {
-                deepseekReq.Temperature = *chatReq.Temperature
-        } else {
-                defaultTemp := 0.7
-                deepseekReq.Temperature = defaultTemp
-        }
+	// Set default temperature if not provided
+	if chatReq.Temperature != nil {
+		deepseekReq.Temperature = *chatReq.Temperature
+	} else {
+		defaultTemp := 0.7
+		deepseekReq.Temperature = defaultTemp
+	}
 
-        // Set default max tokens if not provided
-        if chatReq.MaxTokens != nil {
-                deepseekReq.MaxTokens = *chatReq.MaxTokens
-        } else {
-                defaultMaxTokens := 4096
-                deepseekReq.MaxTokens = defaultMaxTokens
-        }
+	// Set default max tokens if not provided
+	if chatReq.MaxTokens != nil {
+		deepseekReq.MaxTokens = *chatReq.MaxTokens
+	} else {
+		defaultMaxTokens := 4096
+		deepseekReq.MaxTokens = defaultMaxTokens
+	}
 
-        // Handle tools and tool choice
-        if len(chatReq.Tools) > 0 {
-                deepseekReq.Tools = chatReq.Tools
-                deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
-        } else if len(chatReq.Functions) > 0 {
-                // Convert legacy functions to tools
-                tools := make([]Tool, len(chatReq.Functions))
-                for i, fn := range chatReq.Functions {
-                        tools[i] = Tool{
-                                Type:     "function",
-                                Function: fn,
-                        }
-                }
-                deepseekReq.Tools = tools
-                deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
-        }
+	// Handle tools and tool choice
+	if len(chatReq.Tools) > 0 {
+		deepseekReq.Tools = convertTools(chatReq.Tools)
+		deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
+	} else if len(chatReq.Functions) > 0 {
+		// Convert legacy functions to tools
+		tools := make([]deepseek.Tool, len(chatReq.Functions))
+		for i, fn := range chatReq.Functions {
+			tools[i] = deepseek.Tool{
+				Type: "function",
+				Function: deepseek.Function{
+					Name:        fn.Name,
+					Parameters:  fn.Parameters,
+					Description: fn.Description,
+				},
+			}
+		}
+		deepseekReq.Tools = tools
+		deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
+	}
 
-        // Create new request body
-        modifiedBody, err := json.Marshal(deepseekReq)
-        if err != nil {
-                log.Printf("Error creating modified request body: %v", err)
-                http.Error(w, "Error creating modified request", http.StatusInternalServerError)
-                return
-        }
+	// Create new request body
+	modifiedBody, err := json.Marshal(deepseekReq)
+	if err != nil {
+		log.Printf("Error creating modified request body: %v", err)
+		http.Error(w, "Error creating modified request", http.StatusInternalServerError)
+		return
+	}
 
-        log.Printf("Modified request body: %s", string(modifiedBody))
+	log.Printf("Modified request body: %s", string(modifiedBody))
 
-        // Create the proxy request to OpenRouter
-        targetURL := openRouterEndpoint + "/chat/completions"
-        if r.URL.RawQuery != "" {
-                targetURL += "?" + r.URL.RawQuery
-        }
+	// Create the proxy request to OpenRouter
+	targetURL := openRouterEndpoint + "/chat/completions"
+	if r.URL.RawQuery != "" {
+		targetURL += "?" + r.URL.RawQuery
+	}
 
-        log.Printf("Forwarding to: %s", targetURL)
-        proxyReq, err := http.NewRequest(r.Method, targetURL, bytes.NewReader(modifiedBody))
-        if err != nil {
-                log.Printf("Error creating proxy request: %v", err)
-                http.Error(w, "Error creating proxy request", http.StatusInternalServerError)
-                return
-        }
+	log.Printf("Forwarding to: %s", targetURL)
+	proxyReq, err := http.NewRequest(r.Method, targetURL, bytes.NewReader(modifiedBody))
+	if err != nil {
+		log.Printf("Error creating proxy request: %v", err)
+		http.Error(w, "Error creating proxy request", http.StatusInternalServerError)
+		return
+	}
 
-        // Copy headers
-        copyHeaders(proxyReq.Header, r.Header)
+	// Copy headers
+	copyHeaders(proxyReq.Header, r.Header)
 
-        // Set OpenRouter API key and required headers
-        proxyReq.Header.Set("Authorization", "Bearer "+openRouterAPIKey)
-        proxyReq.Header.Set("Content-Type", "application/json")
-        proxyReq.Header.Set("HTTP-Referer", "https://github.com/danilofalcao/cursor-deepseek") // Optional, for OpenRouter rankings
-        proxyReq.Header.Set("X-Title", "Cursor DeepSeek") // Optional, for OpenRouter rankings
-        if chatReq.Stream {
-                proxyReq.Header.Set("Accept", "text/event-stream")
-        }
+	// Set OpenRouter API key and required headers
+	proxyReq.Header.Set("Authorization", "Bearer "+openRouterAPIKey)
+	proxyReq.Header.Set("Content-Type", "application/json")
+	proxyReq.Header.Set("HTTP-Referer", "https://github.com/danilofalcao/cursor-deepseek") // Optional, for OpenRouter rankings
+	proxyReq.Header.Set("X-Title", "Cursor DeepSeek")                                      // Optional, for OpenRouter rankings
+	if chatReq.Stream {
+		proxyReq.Header.Set("Accept", "text/event-stream")
+	}
 
-        // Add Accept-Language header from request
-        if acceptLanguage := r.Header.Get("Accept-Language"); acceptLanguage != "" {
-                proxyReq.Header.Set("Accept-Language", acceptLanguage)
-        }
+	// Add Accept-Language header from request
+	if acceptLanguage := r.Header.Get("Accept-Language"); acceptLanguage != "" {
+		proxyReq.Header.Set("Accept-Language", acceptLanguage)
+	}
 
-        log.Printf("Proxy request headers: %v", proxyReq.Header)
+	log.Printf("Proxy request headers: %v", proxyReq.Header)
 
-        // Create a custom client with keepalive
-        client := &http.Client{
-                Transport: &http2.Transport{
-                        AllowHTTP: true,
-                        DialTLS:   nil,
-                },
-                // Remove global timeout as we'll handle timeouts per request type
-                Timeout: 0,
-        }
+	// Create a custom client with keepalive
+	client := &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLS:   nil,
+		},
+		// Remove global timeout as we'll handle timeouts per request type
+		Timeout: 0,
+	}
 
-        // Create context with timeout based on streaming
-        ctx := context.Background()
-        if !chatReq.Stream {
-                // Use timeout only for non-streaming requests
-                var cancel context.CancelFunc
-                ctx, cancel = context.WithTimeout(ctx, 5*time.Minute)
-                defer cancel()
-        }
+	// Create context with timeout based on streaming
+	ctx := context.Background()
+	if !chatReq.Stream {
+		// Use timeout only for non-streaming requests
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+	}
 
-        // Create the request with context
-        proxyReq = proxyReq.WithContext(ctx)
+	// Create the request with context
+	proxyReq = proxyReq.WithContext(ctx)
 
-        // Send the request
-        resp, err := client.Do(proxyReq)
-        if err != nil {
-                log.Printf("Error forwarding request: %v", err)
-                http.Error(w, "Error forwarding request", http.StatusBadGateway)
-                return
-        }
-        defer resp.Body.Close()
+	// Send the request
+	resp, err := client.Do(proxyReq)
+	if err != nil {
+		log.Printf("Error forwarding request: %v", err)
+		http.Error(w, "Error forwarding request", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
 
-        log.Printf("OpenRouter response status: %d", resp.StatusCode)
-        log.Printf("OpenRouter response headers: %v", resp.Header)
+	log.Printf("OpenRouter response status: %d", resp.StatusCode)
+	log.Printf("OpenRouter response headers: %v", resp.Header)
 
-        // Handle error responses
-        if resp.StatusCode >= 400 {
-                respBody, err := io.ReadAll(resp.Body)
-                if err != nil {
-                        log.Printf("Error reading error response: %v", err)
-                        http.Error(w, "Error reading response", http.StatusInternalServerError)
-                        return
-                }
-                log.Printf("OpenRouter error response: %s", string(respBody))
+	// Handle error responses
+	if resp.StatusCode >= 400 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error reading error response: %v", err)
+			http.Error(w, "Error reading response", http.StatusInternalServerError)
+			return
+		}
+		log.Printf("OpenRouter error response: %s", string(respBody))
 
-                // Forward the error response
-                for k, v := range resp.Header {
-                        w.Header()[k] = v
-                }
-                w.Header().Set("Content-Type", "application/json")
-                w.WriteHeader(resp.StatusCode)
-                w.Write(respBody)
-                return
-        }
+		// Forward the error response
+		for k, v := range resp.Header {
+			w.Header()[k] = v
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		w.Write(respBody)
+		return
+	}
 
-        // Handle streaming response
-        if chatReq.Stream {
-                handleStreamingResponse(w, resp)
-                return
-        }
+	// Handle streaming response
+	if chatReq.Stream {
+		handleStreamingResponse(w, resp)
+		return
+	}
 
-        // Handle regular response
-        handleRegularResponse(w, resp)
+	// Handle regular response
+	handleRegularResponse(w, resp, originalModel)
+}
+
+func convertTools(tools []openai.Tool) []deepseek.Tool {
+	converted := make([]deepseek.Tool, len(tools))
+	for i, tool := range tools {
+		converted[i] = deepseek.Tool{
+			Type: tool.Type,
+			Function: deepseek.Function{
+				Name:        tool.Function.Name,
+				Parameters:  tool.Function.Parameters,
+				Description: tool.Function.Description,
+			},
+		}
+	}
+	return converted
 }
 
 func handleStreamingResponse(w http.ResponseWriter, resp *http.Response) {
-        log.Printf("Starting streaming response handling")
+	log.Printf("Starting streaming response handling")
 
-        // Set headers for streaming response
-        w.Header().Set("Content-Type", "text/event-stream")
-        w.Header().Set("Cache-Control", "no-cache")
-        w.Header().Set("Connection", "keep-alive")
-        w.WriteHeader(resp.StatusCode)
+	// Set headers for streaming response
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(resp.StatusCode)
 
-        // Create a buffered reader for the response body
-        reader := bufio.NewReaderSize(resp.Body, 1024)
+	// Create a buffered reader for the response body
+	reader := bufio.NewReaderSize(resp.Body, 1024)
 
-        // Create a context that will be cancelled when the client disconnects
-        ctx, cancel := context.WithCancel(context.Background())
-        defer cancel()
+	// Create a context that will be cancelled when the client disconnects
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-        // Create a channel to detect client disconnection
-        clientGone := w.(http.CloseNotifier).CloseNotify()
+	// Create a channel to detect client disconnection
+	clientGone := w.(http.CloseNotifier).CloseNotify()
 
-        // Create a channel for errors
-        errChan := make(chan error, 1)
+	// Create a channel for errors
+	errChan := make(chan error, 1)
 
-        // Start processing in a goroutine
-        go func() {
-                defer close(errChan)
-                for {
-                        select {
-                        case <-ctx.Done():
-                                return
-                        case <-clientGone:
-                                log.Printf("Client connection closed")
-                                cancel()
-                                return
-                        default:
-                                // Read until we get a complete SSE message
-                                var buffer bytes.Buffer
-                                for {
-                                        line, err := reader.ReadBytes('\n')
-                                        if err != nil {
-                                                if err == io.EOF {
-                                                        log.Printf("EOF reached")
-                                                        return
-                                                }
-                                                log.Printf("Error reading from response: %v", err)
-                                                errChan <- err
-                                                return
-                                        }
+	// Start processing in a goroutine
+	go func() {
+		defer close(errChan)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-clientGone:
+				log.Printf("Client connection closed")
+				cancel()
+				return
+			default:
+				// Read until we get a complete SSE message
+				var buffer bytes.Buffer
+				for {
+					line, err := reader.ReadBytes('\n')
+					if err != nil {
+						if err == io.EOF {
+							log.Printf("EOF reached")
+							return
+						}
+						log.Printf("Error reading from response: %v", err)
+						errChan <- err
+						return
+					}
 
-                                        // Log the received line for debugging
-                                        log.Printf("Received line: %s", string(line))
+					// Log the received line for debugging
+					log.Printf("Received line: %s", string(line))
 
-                                        // Write to buffer
-                                        buffer.Write(line)
+					// Write to buffer
+					buffer.Write(line)
 
-                                        // If we've reached the end of an event (double newline)
-                                        if bytes.HasSuffix(buffer.Bytes(), []byte("\n\n")) {
-                                                break
-                                        }
-                                }
+					// If we've reached the end of an event (double newline)
+					if bytes.HasSuffix(buffer.Bytes(), []byte("\n\n")) {
+						break
+					}
+				}
 
-                                // Get the complete message
-                                message := buffer.Bytes()
+				// Get the complete message
+				message := buffer.Bytes()
 
-                                // Skip if empty
-                                if len(bytes.TrimSpace(message)) == 0 {
-                                        continue
-                                }
+				// Skip if empty
+				if len(bytes.TrimSpace(message)) == 0 {
+					continue
+				}
 
-                                // Write the message
-                                if _, err := w.Write(message); err != nil {
-                                        log.Printf("Error writing to client: %v", err)
-                                        errChan <- err
-                                        return
-                                }
+				// Write the message
+				if _, err := w.Write(message); err != nil {
+					log.Printf("Error writing to client: %v", err)
+					errChan <- err
+					return
+				}
 
-                                // Flush after each complete message
-                                if f, ok := w.(http.Flusher); ok {
-                                        f.Flush()
-                                        log.Printf("Flushed message to client")
-                                }
-                        }
-                }
-        }()
+				// Flush after each complete message
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+					log.Printf("Flushed message to client")
+				}
+			}
+		}
+	}()
 
-        // Wait for completion or error
-        select {
-        case err := <-errChan:
-                if err != nil {
-                        log.Printf("Error in streaming response: %v", err)
-                }
-        case <-clientGone:
-                log.Printf("Client disconnected")
-        case <-ctx.Done():
-                log.Printf("Context cancelled")
-        }
+	// Wait for completion or error
+	select {
+	case err := <-errChan:
+		if err != nil {
+			log.Printf("Error in streaming response: %v", err)
+		}
+	case <-clientGone:
+		log.Printf("Client disconnected")
+	case <-ctx.Done():
+		log.Printf("Context cancelled")
+	}
 
-        log.Printf("Streaming response handler completed")
+	log.Printf("Streaming response handler completed")
 }
 
-func handleRegularResponse(w http.ResponseWriter, resp *http.Response) {
-        log.Printf("Handling regular (non-streaming) response")
-        log.Printf("Response status: %d", resp.StatusCode)
-        log.Printf("Response headers: %+v", resp.Header)
+func handleRegularResponse(w http.ResponseWriter, resp *http.Response, originalModel string) {
+	log.Printf("Handling regular (non-streaming) response")
+	log.Printf("Response status: %d", resp.StatusCode)
+	log.Printf("Response headers: %+v", resp.Header)
 
-        // Read and log response body
-        body, err := readResponse(resp)
-        if err != nil {
-                log.Printf("Error reading response: %v", err)
-                http.Error(w, "Error reading response from upstream", http.StatusInternalServerError)
-                return
-        }
+	// Read and log response body
+	body, err := readResponse(resp)
+	if err != nil {
+		log.Printf("Error reading response: %v", err)
+		http.Error(w, "Error reading response from upstream", http.StatusInternalServerError)
+		return
+	}
 
-        log.Printf("Original response body: %s", string(body))
+	log.Printf("Original response body: %s", string(body))
 
-        // Parse the DeepSeek response
-        var deepseekResp map[string]interface{}
-        if err := json.Unmarshal(body, &deepseekResp); err != nil {
-                log.Printf("Error parsing DeepSeek response: %v", err)
-                w.WriteHeader(http.StatusInternalServerError)
-                return
-        }
+	// Parse the DeepSeek response
+	var deepseekResp deepseek.Response
+	if err := json.Unmarshal(body, &deepseekResp); err != nil {
+		log.Printf("Error parsing DeepSeek response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-        // Use the original model name instead of hardcoding gpt-4o
-        originalModel := deepseekResp["model"].(string)
-        deepseekResp["model"] = originalModel
+	// Use the original model name instead of hardcoding gpt-4o
+	deepseekResp.Model = originalModel
 
-        // Process choices to ensure tool calls are properly formatted
-        if choices, ok := deepseekResp["choices"].([]interface{}); ok {
-                for _, choice := range choices {
-                        if choiceMap, ok := choice.(map[string]interface{}); ok {
-                                if message, ok := choiceMap["message"].(map[string]interface{}); ok {
-                                        // Handle tool calls in the message
-                                        if toolCalls, ok := message["tool_calls"].([]interface{}); ok {
-                                                for i, tc := range toolCalls {
-                                                        if tcMap, ok := tc.(map[string]interface{}); ok {
-                                                                // Ensure type is set to "function"
-                                                                tcMap["type"] = "function"
+	// If we have tools calls, make sure the have type "function"
+	for i, choice := range deepseekResp.Choices {
+		if choice.Message.ToolCalls != nil {
+			for j, tc := range choice.Message.ToolCalls {
+				tc.Type = "function"
+				choice.Message.ToolCalls[j] = tc
+			}
+			deepseekResp.Choices[i] = choice
+		}
+	}
 
-                                                                // Ensure function field is properly formatted
-                                                                if fn, ok := tcMap["function"].(map[string]interface{}); ok {
-                                                                        // Make sure required fields exist
-                                                                        if _, ok := fn["name"]; !ok {
-                                                                                fn["name"] = ""
-                                                                        }
-                                                                        if _, ok := fn["arguments"]; !ok {
-                                                                                fn["arguments"] = "{}"
-                                                                        }
-                                                                }
-                                                        }
-                                                        toolCalls[i] = tc
-                                                }
-                                                message["tool_calls"] = toolCalls
-                                        }
-                                }
-                        }
-                }
-        }
+	// Convert back to JSON
+	modifiedBody, err := json.Marshal(deepseekResp)
+	if err != nil {
+		log.Printf("Error creating modified response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-        // Convert back to JSON
-        modifiedBody, err := json.Marshal(deepseekResp)
-        if err != nil {
-                log.Printf("Error creating modified response: %v", err)
-                w.WriteHeader(http.StatusInternalServerError)
-                return
-        }
+	log.Printf("Modified response body: %s", string(modifiedBody))
 
-        log.Printf("Modified response body: %s", string(modifiedBody))
-
-        // Set response headers
-        w.Header().Set("Content-Type", "application/json")
-        w.WriteHeader(resp.StatusCode)
-        w.Write(modifiedBody)
-        log.Printf("Modified response sent successfully")
+	// Set response headers
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	w.Write(modifiedBody)
+	log.Printf("Modified response sent successfully")
 }
 
 func copyHeaders(dst, src http.Header) {
-        // Headers to skip
-        skipHeaders := map[string]bool{
-                "Content-Length":    true,
-                "Content-Encoding":  true,
-                "Transfer-Encoding": true,
-                "Connection":        true,
-        }
+	// Headers to skip
+	skipHeaders := map[string]bool{
+		"Content-Length":    true,
+		"Content-Encoding":  true,
+		"Transfer-Encoding": true,
+		"Connection":        true,
+	}
 
-        for k, vv := range src {
-                if !skipHeaders[k] {
-                        for _, v := range vv {
-                                dst.Add(k, v)
-                        }
-                }
-        }
+	for k, vv := range src {
+		if !skipHeaders[k] {
+			for _, v := range vv {
+				dst.Add(k, v)
+			}
+		}
+	}
 }
 
 func handleModelsRequest(w http.ResponseWriter) {
-        log.Printf("Handling models request")
+	log.Printf("Handling models request")
 
-        response := ModelsResponse{
-                Object: "list",
-                Data: []Model{
-                        {
-                                ID:      deepseekChatModel,
-                                Object:  "model",
-                                Created: time.Now().Unix(),
-                                OwnedBy: "deepseek",
-                        },
-                },
-        }
+	response := openai.ModelsResponse{
+		Object: "list",
+		Data: []openai.Model{
+			{
+				ID:      defaultChatModel,
+				Object:  "model",
+				Created: time.Now().Unix(),
+				OwnedBy: "deepseek",
+			},
+		},
+	}
 
-        w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(response)
-        log.Printf("Models response sent successfully")
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+	log.Printf("Models response sent successfully")
 }
 
 func readResponse(resp *http.Response) ([]byte, error) {
-        var reader io.Reader = resp.Body
+	var reader io.Reader = resp.Body
 
-        switch resp.Header.Get("Content-Encoding") {
-        case "gzip":
-                gzReader, err := gzip.NewReader(resp.Body)
-                if err != nil {
-                        return nil, fmt.Errorf("error creating gzip reader: %v", err)
-                }
-                defer gzReader.Close()
-                reader = gzReader
-        case "br":
-                reader = brotli.NewReader(resp.Body)
-        case "deflate":
-                reader = flate.NewReader(resp.Body)
-        }
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error creating gzip reader: %v", err)
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	case "br":
+		reader = brotli.NewReader(resp.Body)
+	case "deflate":
+		reader = flate.NewReader(resp.Body)
+	}
 
-        return io.ReadAll(reader)
+	return io.ReadAll(reader)
 }


### PR DESCRIPTION
**Description:**  
This pull request refactors the type definitions used in the OpenAI frontend and various backends, extracting them into separate packages for improved organization and maintainability. This change allows single, explicit type definition for reuse between frontend and backend logic, making it easier to develop and test each component independently.

**Context:**  
The previous implementation combined types for both the frontend and backends in each script, leading to potential conflicts and difficulties in managing changes across different parts of the application. By extracting the types into separate packages, this pull request:

* Simplifies the project structure by categorizing types based on their usage
* Reduces coupling between components, making it easier to maintain and update individual parts without affecting others
* Enhances code readability by clearly separating types for each API
