### PR TITLE
Extract Backend Implementations into Separate Packages with Interface-Based Abstraction

### DIFF
--- a/internal/api/openai/v1/types.go
+++ b/internal/api/openai/v1/types.go
@@ -1,4 +1,4 @@
-package v1
+package openai
 
 import (
 	"encoding/json"

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -1,3 +1,10 @@
 package backend
 
+import "net/http"
+
 // TODO: Create a backend interface
+
+type Backend interface {
+	HandleModelsRequest(w http.ResponseWriter)
+	HandleChatCompletions(w http.ResponseWriter, r *http.Request)
+}

--- a/internal/backend/deepseek/convert.go
+++ b/internal/backend/deepseek/convert.go
@@ -1,0 +1,153 @@
+package deepseek
+
+import (
+	"log"
+
+	"github.com/danilofalcao/cursor-deepseek/internal/api/deepseek/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+)
+
+func convertTools(tools []openai.Tool) []deepseek.Tool {
+	converted := make([]deepseek.Tool, len(tools))
+	for i, tool := range tools {
+		converted[i] = deepseek.Tool{
+			Type: tool.Type,
+			Function: deepseek.Function{
+				Name:        tool.Function.Name,
+				Parameters:  tool.Function.Parameters,
+				Description: tool.Function.Description,
+			},
+		}
+	}
+	return converted
+}
+
+func convertToolChoice(choice interface{}) string {
+	if choice == nil {
+		return ""
+	}
+
+	// If string "auto" or "none"
+	if str, ok := choice.(string); ok {
+		switch str {
+		case "auto", "none":
+			return str
+		}
+	}
+
+	// Try to parse as map for function call
+	if choiceMap, ok := choice.(map[string]interface{}); ok {
+		if choiceMap["type"] == "function" {
+			return "auto" // DeepSeek doesn't support specific function selection, default to auto
+		}
+	}
+
+	return ""
+}
+
+func convertMessages(messages []openai.Message) []deepseek.Message {
+	converted := make([]deepseek.Message, len(messages))
+	for i, msg := range messages {
+		log.Printf("Converting message %d - Role: %s", i, msg.Role)
+		var content string
+		switch msg.GetContent().(type) {
+		case openai.Content_String:
+			content = msg.GetContentString()
+		case openai.Content_Array:
+			contentArray := msg.GetContentArray()
+			for i := range contentArray {
+				t := contentArray.GetContentPartTextAtIndex(i).Text
+				if t != "" {
+					content += "; " + t
+				}
+			}
+		}
+		converted[i] = deepseek.Message{
+			Role:       msg.Role,
+			Content:    content,
+			ToolCallID: msg.ToolCallID,
+			Name:       msg.Name,
+		}
+
+		// Handle assistant messages with tool calls
+		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			log.Printf("Processing assistant message with %d tool calls", len(msg.ToolCalls))
+			// DeepSeek expects tool_calls in a specific format
+			toolCalls := make([]deepseek.ToolCall, len(msg.ToolCalls))
+			for j, tc := range msg.ToolCalls {
+				toolCalls[j] = deepseek.ToolCall{
+					ID:   tc.ID,
+					Type: "function",
+					Function: deepseek.ToolCallFunction{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
+				}
+				log.Printf("Tool call %d - ID: %s, Function: %s", j, tc.ID, tc.Function.Name)
+			}
+			converted[i].ToolCalls = toolCalls
+		}
+
+		// Handle function response messages
+		if msg.Role == "function" {
+			log.Printf("Converting function response to tool response")
+			// Convert to tool response format
+			converted[i].Role = "tool"
+		}
+	}
+
+	// Log the final converted messages
+	for i, msg := range converted {
+		log.Printf("Final message %d - Role: %s, Content: %s", i, msg.Role, truncateString(msg.Content, 50))
+		if len(msg.ToolCalls) > 0 {
+			log.Printf("Message %d has %d tool calls", i, len(msg.ToolCalls))
+		}
+	}
+
+	return converted
+}
+
+func convertResponseChoices(choices []deepseek.Choice) []openai.Choice {
+	openaiChoices := make([]openai.Choice, len(choices))
+	for i, choice := range choices {
+		openaiChoices[i] = openai.Choice{
+			Index:        choice.Index,
+			Message:      convertResponseMessage(choice.Message),
+			FinishReason: choice.FinishReason,
+		}
+	}
+	return openaiChoices
+}
+
+func convertResponseMessage(message deepseek.Message) openai.Message {
+	return openai.Message{
+		Role: message.Role,
+		Content: openai.Content_String{
+			Content: message.Content,
+		},
+		ToolCalls:  convertResponseToolCalls(message.ToolCalls),
+		ToolCallID: message.ToolCallID,
+		Name:       message.Name,
+	}
+}
+
+func convertResponseToolCalls(toolCalls []deepseek.ToolCall) []openai.ToolCall {
+	openaiToolCalls := make([]openai.ToolCall, 0)
+	for i, tc := range toolCalls {
+		log.Printf("Tool call %d: %+v", i, tc)
+		// Ensure the tool call has the required fields
+		if tc.Function.Name == "" {
+			log.Printf("Warning: Empty function name in tool call %d", i)
+			continue
+		}
+		openaiToolCalls = append(openaiToolCalls, openai.ToolCall{
+			ID:   tc.ID,
+			Type: tc.Type,
+			Function: openai.ToolCallFunction{
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			},
+		})
+	}
+	return openaiToolCalls
+}

--- a/internal/backend/deepseek/deepseek.go
+++ b/internal/backend/deepseek/deepseek.go
@@ -1,3 +1,367 @@
 package deepseek
 
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/danilofalcao/cursor-deepseek/internal/api/deepseek/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend"
+	"golang.org/x/net/http2"
+)
+
 // TODO: Implement the DeepSeek backend as a backend.Backend
+
+var _ backend.Backend = &deepseekBackend{}
+
+type deepseekBackend struct {
+	endpoint string
+	model    string
+	apikey   string
+}
+
+type Options struct {
+	Endpoint string
+	Model    string
+	ApiKey   string
+}
+
+func NewDeepseekBackend(opts Options) backend.Backend {
+	return &deepseekBackend{
+		endpoint: opts.Endpoint,
+		model:    opts.Model,
+	}
+}
+
+func (b *deepseekBackend) HandleModelsRequest(w http.ResponseWriter) {
+	log.Printf("Handling models request")
+
+	// Get the requested model from the query parameters
+	response := openai.ModelsResponse{
+		Object: "list",
+		Data: []openai.Model{
+			{
+				ID:      b.model,
+				Object:  "model",
+				Created: time.Now().Unix(),
+				OwnedBy: "deepseek",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+	log.Printf("Models response sent successfully")
+}
+func (b *deepseekBackend) HandleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	// Read and log request body for debugging
+	var chatReq openai.ChatCompletionRequest
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Error reading request body: %v", err)
+		http.Error(w, "Error reading request", http.StatusBadRequest)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		log.Printf("Error parsing request JSON: %v", err)
+		log.Printf("Raw request body: %s", string(body))
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("Parsed request: %+v", chatReq)
+
+	// Restore the body for further reading
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	log.Printf("Request body: %s", string(body))
+
+	// Parse the request to check for streaming - reuse existing chatReq
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		log.Printf("Error parsing request JSON: %v", err)
+		http.Error(w, "Error parsing request", http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("Requested model: %s", chatReq.Model)
+
+	// Store original model name for response
+	originalModel := chatReq.Model
+
+	// Convert to deepseek-chat internally
+	chatReq.Model = b.model
+	log.Printf("Model converted to: %s (original: %s)", b.model, originalModel)
+
+	// Convert to DeepSeek request format
+	deepseekReq := deepseek.Request{
+		Model:    b.model,
+		Messages: convertMessages(chatReq.Messages),
+		Stream:   chatReq.Stream,
+	}
+
+	// Copy optional parameters if present
+	if chatReq.Temperature != nil {
+		deepseekReq.Temperature = *chatReq.Temperature
+	}
+	if chatReq.MaxTokens != nil {
+		deepseekReq.MaxTokens = *chatReq.MaxTokens
+	}
+
+	// Handle tools/functions
+	if len(chatReq.Tools) > 0 {
+		deepseekReq.Tools = convertTools(chatReq.Tools)
+		if tc := convertToolChoice(chatReq.ToolChoice); tc != "" {
+			deepseekReq.ToolChoice = tc
+		}
+	} else if len(chatReq.Functions) > 0 {
+		// Convert functions to tools format
+		tools := make([]deepseek.Tool, len(chatReq.Functions))
+		for i, fn := range chatReq.Functions {
+			tools[i] = deepseek.Tool{
+				Type: "function",
+				Function: deepseek.Function{
+					Name:        fn.Name,
+					Description: fn.Description,
+					Parameters:  fn.Parameters,
+				},
+			}
+		}
+		deepseekReq.Tools = tools
+
+		// Convert tool_choice if present
+		if tc := convertToolChoice(chatReq.ToolChoice); tc != "" {
+			deepseekReq.ToolChoice = tc
+		}
+	}
+
+	// Create new request body
+	modifiedBody, err := json.Marshal(deepseekReq)
+	if err != nil {
+		log.Printf("Error creating modified request body: %v", err)
+		http.Error(w, "Error creating modified request", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Modified request body: %s", string(modifiedBody))
+
+	// Create the proxy request to DeepSeek
+	targetURL := b.endpoint + r.URL.Path
+	if r.URL.RawQuery != "" {
+		targetURL += "?" + r.URL.RawQuery
+	}
+
+	log.Printf("Forwarding to: %s", targetURL)
+	proxyReq, err := http.NewRequest(r.Method, targetURL, bytes.NewReader(modifiedBody))
+	if err != nil {
+		log.Printf("Error creating proxy request: %v", err)
+		http.Error(w, "Error creating proxy request", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers
+	copyHeaders(proxyReq.Header, r.Header)
+
+	// Set DeepSeek API key and content type
+	proxyReq.Header.Set("Authorization", "Bearer "+b.apikey)
+	proxyReq.Header.Set("Content-Type", "application/json")
+	if chatReq.Stream {
+		proxyReq.Header.Set("Accept", "text/event-stream")
+	}
+
+	// Add Accept-Language header from request
+	if acceptLanguage := r.Header.Get("Accept-Language"); acceptLanguage != "" {
+		proxyReq.Header.Set("Accept-Language", acceptLanguage)
+	}
+
+	log.Printf("Proxy request headers: %v", proxyReq.Header)
+
+	// Create a custom client with keepalive
+	client := &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLS:   nil,
+		},
+		Timeout: 5 * time.Minute,
+	}
+
+	// Send the request
+	resp, err := client.Do(proxyReq)
+	if err != nil {
+		log.Printf("Error forwarding request: %v", err)
+		http.Error(w, "Error forwarding request", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	log.Printf("DeepSeek response status: %d", resp.StatusCode)
+	log.Printf("DeepSeek response headers: %v", resp.Header)
+
+	// Handle error responses
+	if resp.StatusCode >= 400 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error reading error response: %v", err)
+			http.Error(w, "Error reading response", http.StatusInternalServerError)
+			return
+		}
+		log.Printf("DeepSeek error response: %s", string(respBody))
+
+		// Forward the error response
+		for k, v := range resp.Header {
+			w.Header()[k] = v
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		w.Write(respBody)
+		return
+	}
+
+	// Handle streaming response
+	if chatReq.Stream {
+		handleStreamingResponse(w, r, resp, originalModel)
+		return
+	}
+
+	// Handle regular response
+	handleRegularResponse(w, resp, originalModel)
+}
+func handleStreamingResponse(w http.ResponseWriter, r *http.Request, resp *http.Response, originalModel string) {
+	log.Printf("Starting streaming response handling with model: %s", originalModel)
+	log.Printf("Response status: %d", resp.StatusCode)
+	log.Printf("Response headers: %+v", resp.Header)
+
+	// Set headers for streaming response
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(resp.StatusCode)
+
+	// Create a buffered reader for the response body
+	reader := bufio.NewReader(resp.Body)
+
+	// Create a context with cancel for cleanup
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	// Start a goroutine to send heartbeats
+	go func() {
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				// Send a heartbeat comment
+				if _, err := w.Write([]byte(": heartbeat\n\n")); err != nil {
+					log.Printf("Error sending heartbeat: %v", err)
+					cancel()
+					return
+				}
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("Context cancelled, ending stream")
+			return
+		default:
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				if err == io.EOF {
+					continue
+				}
+				log.Printf("Error reading stream: %v", err)
+				cancel()
+				return
+			}
+
+			// Skip empty lines
+			if len(bytes.TrimSpace(line)) == 0 {
+				continue
+			}
+
+			// Write the line to the response
+			if _, err := w.Write(line); err != nil {
+				log.Printf("Error writing to response: %v", err)
+				cancel()
+				return
+			}
+
+			// Flush the response writer
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			} else {
+				log.Printf("Warning: ResponseWriter does not support Flush")
+			}
+		}
+	}
+}
+
+func handleRegularResponse(w http.ResponseWriter, resp *http.Response, originalModel string) {
+	log.Printf("Handling regular (non-streaming) response")
+	log.Printf("Response status: %d", resp.StatusCode)
+	log.Printf("Response headers: %+v", resp.Header)
+
+	// Read and log response body
+	body, err := readResponse(resp)
+	if err != nil {
+		log.Printf("Error reading response: %v", err)
+		http.Error(w, "Error reading response from upstream", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Original response body: %s", string(body))
+
+	// Parse the DeepSeek response
+	var deepseekResp deepseek.Response
+
+	if err := json.Unmarshal(body, &deepseekResp); err != nil {
+		log.Printf("Error parsing DeepSeek response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Convert to OpenAI format
+	openAIResp := openai.ChatCompletionResponse{
+		ID:      deepseekResp.ID,
+		Object:  "chat.completion",
+		Created: deepseekResp.Created,
+		Model:   originalModel,
+		Usage: openai.Usage{
+			PromptTokens:     deepseekResp.Usage.PromptTokens,
+			CompletionTokens: deepseekResp.Usage.CompletionTokens,
+			TotalTokens:      deepseekResp.Usage.TotalTokens,
+		},
+		Choices: convertResponseChoices(deepseekResp.Choices),
+	}
+
+	// Convert back to JSON
+	modifiedBody, err := json.Marshal(openAIResp)
+	if err != nil {
+		log.Printf("Error creating modified response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Modified response body: %s", string(modifiedBody))
+
+	// Set response headers
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	w.Write(modifiedBody)
+	log.Printf("Modified response sent successfully")
+}

--- a/internal/backend/deepseek/utils.go
+++ b/internal/backend/deepseek/utils.go
@@ -1,0 +1,56 @@
+package deepseek
+
+import (
+	"compress/flate"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/andybalholm/brotli"
+)
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+func copyHeaders(dst, src http.Header) {
+	// Headers to skip
+	skipHeaders := map[string]bool{
+		"Content-Length":    true,
+		"Content-Encoding":  true,
+		"Transfer-Encoding": true,
+		"Connection":        true,
+	}
+
+	for k, vv := range src {
+		if !skipHeaders[k] {
+			for _, v := range vv {
+				dst.Add(k, v)
+			}
+		}
+	}
+}
+
+func readResponse(resp *http.Response) ([]byte, error) {
+	var reader io.Reader = resp.Body
+
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error creating gzip reader: %v", err)
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	case "br":
+		reader = brotli.NewReader(resp.Body)
+	case "deflate":
+		reader = flate.NewReader(resp.Body)
+	}
+
+	return io.ReadAll(reader)
+}

--- a/internal/backend/ollama/convert.go
+++ b/internal/backend/ollama/convert.go
@@ -2,7 +2,7 @@ package ollama
 
 import (
 	ollama "github.com/danilofalcao/cursor-deepseek/internal/api/ollama/v1"
-	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
 )
 
 func convertMessages(messages []openai.Message) []ollama.Message {

--- a/internal/backend/ollama/convert.go
+++ b/internal/backend/ollama/convert.go
@@ -1,0 +1,30 @@
+package ollama
+
+import (
+	ollama "github.com/danilofalcao/cursor-deepseek/internal/api/ollama/v1"
+	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+)
+
+func convertMessages(messages []openai.Message) []ollama.Message {
+	ollamaMessages := make([]ollama.Message, len(messages))
+	for i, message := range messages {
+		var content string
+		switch message.GetContent().(type) {
+		case openai.Content_String:
+			content = message.GetContentString()
+		case openai.Content_Array:
+			contentArray := message.GetContentArray()
+			for i := range contentArray {
+				t := contentArray.GetContentPartTextAtIndex(i).Text
+				if t != "" {
+					content += "; " + t
+				}
+			}
+		}
+		ollamaMessages[i] = ollama.Message{
+			Role:    message.Role,
+			Content: content,
+		}
+	}
+	return ollamaMessages
+}

--- a/internal/backend/ollama/ollama.go
+++ b/internal/backend/ollama/ollama.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	ollama "github.com/danilofalcao/cursor-deepseek/internal/api/ollama/v1"
-	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
 	"github.com/danilofalcao/cursor-deepseek/internal/backend"
 )
 

--- a/internal/backend/ollama/ollama.go
+++ b/internal/backend/ollama/ollama.go
@@ -1,3 +1,212 @@
 package ollama
 
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	ollama "github.com/danilofalcao/cursor-deepseek/internal/api/ollama/v1"
+	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend"
+)
+
 // TODO: Implement the Ollama backend as a backend.Backend
+
+var _ backend.Backend = &ollamaBackend{}
+
+type ollamaBackend struct {
+	endpoint string
+	model    string
+}
+
+type Options struct {
+	Endpoint string
+	Model    string
+}
+
+func NewOllamaBackend(opts Options) backend.Backend {
+	return &ollamaBackend{
+		endpoint: opts.Endpoint,
+		model:    opts.Model,
+	}
+}
+
+func (b *ollamaBackend) HandleModelsRequest(w http.ResponseWriter) {
+	log.Printf("Handling models request")
+
+	response := openai.ModelsResponse{
+		Object: "list",
+		Data: []openai.Model{
+			{
+				ID:      b.model,
+				Object:  "model",
+				Created: time.Now().Unix(),
+				OwnedBy: "ollama",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+	log.Printf("Models response sent successfully")
+}
+func (b *ollamaBackend) HandleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	var chatReq openai.ChatCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&chatReq); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("chatReq: %+v", chatReq)
+
+	// Store original model name for response
+	originalModel := chatReq.Model
+	if originalModel == "" {
+		originalModel = b.model
+	}
+
+	// Always use the configured model internally
+	chatReq.Model = b.model
+	log.Printf("Model converted to: %s (original: %s)", b.model, originalModel)
+
+	// Convert to Ollama request format
+	ollamaReq := ollama.Request{
+		Model:    b.model,
+		Messages: convertMessages(chatReq.Messages),
+		Stream:   chatReq.Stream,
+	}
+
+	if chatReq.Temperature != nil {
+		ollamaReq.Temperature = *chatReq.Temperature
+	}
+	if chatReq.MaxTokens != nil {
+		ollamaReq.MaxTokens = *chatReq.MaxTokens
+	}
+
+	// Create Ollama request
+	ollamaReqBody, err := json.Marshal(ollamaReq)
+	if err != nil {
+		log.Printf("ERROR: failed to marshal ollama request: %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("ollamaReqBody: %s", string(ollamaReqBody))
+	// Send request to Ollama
+	ollamaResp, err := http.Post(
+		fmt.Sprintf("%s/chat", b.endpoint),
+		"application/json",
+		bytes.NewBuffer(ollamaReqBody),
+	)
+	if err != nil {
+		log.Printf("ERROR: POST failed: %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer ollamaResp.Body.Close()
+
+	if chatReq.Stream {
+		handleStreamingResponse(w, r, ollamaResp, originalModel)
+	} else {
+		handleRegularResponse(w, ollamaResp, originalModel)
+	}
+}
+
+func handleStreamingResponse(w http.ResponseWriter, _ *http.Request, resp *http.Response, originalModel string) {
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("Error reading stream: %v", err)
+			}
+			break
+		}
+
+		var ollamaResp ollama.Response
+		if err := json.Unmarshal(line, &ollamaResp); err != nil {
+			log.Printf("Error unmarshaling response: %v", err)
+			continue
+		}
+
+		openAIResp := openai.ChatCompletionStreamResponse{
+			ID:      "chatcmpl-" + time.Now().Format("20060102150405"),
+			Object:  "chat.completion.chunk",
+			Created: time.Now().Unix(),
+			Model:   originalModel,
+			Choices: []openai.StreamChoice{
+				{
+					Index: 0,
+					Delta: openai.Delta{
+						Content: openai.Content_String{Content: ollamaResp.Message.Content},
+						Role:    "assistant",
+					},
+				},
+			},
+		}
+
+		if ollamaResp.Done {
+			openAIResp.Choices[0].FinishReason = "stop"
+		}
+
+		if data, err := json.Marshal(openAIResp); err == nil {
+			log.Printf("data: %+v", string(data))
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		} else {
+			log.Printf("ERROR: failed to marshal openAIResp: %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if ollamaResp.Done {
+			break
+		}
+	}
+}
+
+func handleRegularResponse(w http.ResponseWriter, resp *http.Response, originalModel string) {
+	var ollamaResp ollama.Response
+	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Convert to OpenAI format
+	openAIResp := openai.ChatCompletionResponse{
+		ID:      "chatcmpl-" + time.Now().Format("20060102150405"),
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   originalModel,
+		Choices: []openai.Choice{
+			{
+				Index: 0,
+				Message: openai.Message{
+					Role:    "assistant",
+					Content: openai.Content_String{Content: ollamaResp.Message.Content},
+				},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	log.Printf("openAIResp: %+v", openAIResp)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(openAIResp)
+}

--- a/internal/backend/openrouter/convert.go
+++ b/internal/backend/openrouter/convert.go
@@ -1,0 +1,119 @@
+package openrouter
+
+import (
+	"log"
+
+	deepseek "github.com/danilofalcao/cursor-deepseek/internal/api/deepseek/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+)
+
+func convertTools(tools []openai.Tool) []deepseek.Tool {
+	converted := make([]deepseek.Tool, len(tools))
+	for i, tool := range tools {
+		converted[i] = deepseek.Tool{
+			Type: tool.Type,
+			Function: deepseek.Function{
+				Name:        tool.Function.Name,
+				Parameters:  tool.Function.Parameters,
+				Description: tool.Function.Description,
+			},
+		}
+	}
+	return converted
+}
+
+func convertToolChoice(choice interface{}) string {
+	if choice == nil {
+		return ""
+	}
+
+	// If string "auto" or "none"
+	if str, ok := choice.(string); ok {
+		switch str {
+		case "auto", "none":
+			return str
+		}
+	}
+
+	// Try to parse as map for function call
+	if choiceMap, ok := choice.(map[string]interface{}); ok {
+		if choiceMap["type"] == "function" {
+			return "auto" // DeepSeek doesn't support specific function selection, default to auto
+		}
+	}
+
+	return ""
+}
+
+func convertToolCalls(toolCalls []openai.ToolCall, toolType string) []deepseek.ToolCall {
+	getToolType := func(toolCall openai.ToolCall) string {
+		if toolType != "" {
+			return toolType
+		}
+		return toolCall.Type
+	}
+	converted := make([]deepseek.ToolCall, len(toolCalls))
+	for i, tc := range toolCalls {
+		converted[i] = deepseek.ToolCall{
+			ID:   tc.ID,
+			Type: getToolType(tc),
+			Function: deepseek.ToolCallFunction{
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			},
+		}
+	}
+	return converted
+}
+
+func convertMessages(messages []openai.Message) []deepseek.Message {
+	converted := make([]deepseek.Message, len(messages))
+	for i, msg := range messages {
+		log.Printf("Converting message %d - Role: %s", i, msg.Role)
+		var content string
+		switch msg.GetContent().(type) {
+		case openai.Content_String:
+			content = msg.GetContentString()
+		case openai.Content_Array:
+			contentArray := msg.GetContentArray()
+			for i := range contentArray {
+				t := contentArray.GetContentPartTextAtIndex(i).Text
+				if t != "" {
+					content += "; " + t
+				}
+			}
+		}
+		converted[i] = deepseek.Message{
+			Role:       msg.Role,
+			Content:    content,
+			ToolCallID: msg.ToolCallID,
+			Name:       msg.Name,
+		}
+
+		// Convert function role to tool role
+		if msg.Role == "function" {
+			converted[i].Role = "tool"
+			converted[i].ToolCalls = convertToolCalls(msg.ToolCalls, "")
+			log.Printf("Converted function role to tool role")
+		}
+
+		// Handle assistant messages with tool calls
+		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			log.Printf("Processing assistant message with %d tool calls", len(msg.ToolCalls))
+
+			// Ensure tool calls are properly formatted
+			converted[i].ToolCalls = convertToolCalls(msg.ToolCalls, "function")
+		}
+
+		// Handle tool response messages
+		if msg.Role == "tool" || msg.Role == "function" {
+			log.Printf("Processing tool/function response message")
+			converted[i].Role = "tool"
+			if msg.Name != "" {
+				log.Printf("Tool response from function: %s", msg.Name)
+			}
+		}
+	}
+
+	return converted
+}

--- a/internal/backend/openrouter/openrouter.go
+++ b/internal/backend/openrouter/openrouter.go
@@ -1,3 +1,404 @@
 package openrouter
 
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	deepseek "github.com/danilofalcao/cursor-deepseek/internal/api/deepseek/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend"
+	"golang.org/x/net/http2"
+)
+
 // TODO: Implement the OpenRouter backend as a backend.Backend
+var _ backend.Backend = &openrouterBackend{}
+
+type openrouterBackend struct {
+	endpoint string
+	model    string
+	apikey   string
+}
+
+type Options struct {
+	Endpoint string
+	Model    string
+	ApiKey   string
+}
+
+func NewOpenrouterBackend(opts Options) backend.Backend {
+	return &openrouterBackend{
+		endpoint: opts.Endpoint,
+		model:    opts.Model,
+	}
+}
+
+func (b *openrouterBackend) HandleModelsRequest(w http.ResponseWriter) {
+	log.Printf("Handling models request")
+
+	response := openai.ModelsResponse{
+		Object: "list",
+		Data: []openai.Model{
+			{
+				ID:      b.model,
+				Object:  "model",
+				Created: time.Now().Unix(),
+				OwnedBy: "deepseek",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+	log.Printf("Models response sent successfully")
+}
+
+func (b *openrouterBackend) HandleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	// Read and log request body for debugging
+	var chatReq openai.ChatCompletionRequest
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Error reading request body: %v", err)
+		http.Error(w, "Error reading request", http.StatusBadRequest)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		log.Printf("Error parsing request JSON: %v", err)
+		log.Printf("Raw request body: %s", string(body))
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("Parsed request: %+v", chatReq)
+
+	// Restore the body for further reading
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	log.Printf("Request body: %s", string(body))
+
+	// Parse the request to check for streaming - reuse existing chatReq
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		log.Printf("Error parsing request JSON: %v", err)
+		http.Error(w, "Error parsing request", http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("Requested model: %s", chatReq.Model)
+
+	// Store original model name for response
+	originalModel := chatReq.Model
+
+	// Convert to deepseek-chat internally
+	chatReq.Model = b.model
+	log.Printf("Model converted to: %s (original: %s)", b.model, originalModel)
+
+	// Convert to DeepSeek request format
+	deepseekReq := deepseek.Request{
+		Model:    b.model,
+		Messages: convertMessages(chatReq.Messages),
+		Stream:   chatReq.Stream,
+	}
+
+	// Set default temperature if not provided
+	if chatReq.Temperature != nil {
+		deepseekReq.Temperature = *chatReq.Temperature
+	} else {
+		defaultTemp := 0.7
+		deepseekReq.Temperature = defaultTemp
+	}
+
+	// Set default max tokens if not provided
+	if chatReq.MaxTokens != nil {
+		deepseekReq.MaxTokens = *chatReq.MaxTokens
+	} else {
+		defaultMaxTokens := 4096
+		deepseekReq.MaxTokens = defaultMaxTokens
+	}
+
+	// Handle tools and tool choice
+	if len(chatReq.Tools) > 0 {
+		deepseekReq.Tools = convertTools(chatReq.Tools)
+		deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
+	} else if len(chatReq.Functions) > 0 {
+		// Convert legacy functions to tools
+		tools := make([]deepseek.Tool, len(chatReq.Functions))
+		for i, fn := range chatReq.Functions {
+			tools[i] = deepseek.Tool{
+				Type: "function",
+				Function: deepseek.Function{
+					Name:        fn.Name,
+					Parameters:  fn.Parameters,
+					Description: fn.Description,
+				},
+			}
+		}
+		deepseekReq.Tools = tools
+		deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
+	}
+
+	// Create new request body
+	modifiedBody, err := json.Marshal(deepseekReq)
+	if err != nil {
+		log.Printf("Error creating modified request body: %v", err)
+		http.Error(w, "Error creating modified request", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Modified request body: %s", string(modifiedBody))
+
+	// Create the proxy request to OpenRouter
+	targetURL := b.endpoint + "/chat/completions"
+	if r.URL.RawQuery != "" {
+		targetURL += "?" + r.URL.RawQuery
+	}
+
+	log.Printf("Forwarding to: %s", targetURL)
+	proxyReq, err := http.NewRequest(r.Method, targetURL, bytes.NewReader(modifiedBody))
+	if err != nil {
+		log.Printf("Error creating proxy request: %v", err)
+		http.Error(w, "Error creating proxy request", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers
+	copyHeaders(proxyReq.Header, r.Header)
+
+	// Set OpenRouter API key and required headers
+	proxyReq.Header.Set("Authorization", "Bearer "+b.apikey)
+	proxyReq.Header.Set("Content-Type", "application/json")
+	proxyReq.Header.Set("HTTP-Referer", "https://github.com/danilofalcao/cursor-deepseek") // Optional, for OpenRouter rankings
+	proxyReq.Header.Set("X-Title", "Cursor DeepSeek")                                      // Optional, for OpenRouter rankings
+	if chatReq.Stream {
+		proxyReq.Header.Set("Accept", "text/event-stream")
+	}
+
+	// Add Accept-Language header from request
+	if acceptLanguage := r.Header.Get("Accept-Language"); acceptLanguage != "" {
+		proxyReq.Header.Set("Accept-Language", acceptLanguage)
+	}
+
+	log.Printf("Proxy request headers: %v", proxyReq.Header)
+
+	// Create a custom client with keepalive
+	client := &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLS:   nil,
+		},
+		// Remove global timeout as we'll handle timeouts per request type
+		Timeout: 0,
+	}
+
+	// Create context with timeout based on streaming
+	ctx := context.Background()
+	if !chatReq.Stream {
+		// Use timeout only for non-streaming requests
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+	}
+
+	// Create the request with context
+	proxyReq = proxyReq.WithContext(ctx)
+
+	// Send the request
+	resp, err := client.Do(proxyReq)
+	if err != nil {
+		log.Printf("Error forwarding request: %v", err)
+		http.Error(w, "Error forwarding request", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	log.Printf("OpenRouter response status: %d", resp.StatusCode)
+	log.Printf("OpenRouter response headers: %v", resp.Header)
+
+	// Handle error responses
+	if resp.StatusCode >= 400 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error reading error response: %v", err)
+			http.Error(w, "Error reading response", http.StatusInternalServerError)
+			return
+		}
+		log.Printf("OpenRouter error response: %s", string(respBody))
+
+		// Forward the error response
+		for k, v := range resp.Header {
+			w.Header()[k] = v
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		w.Write(respBody)
+		return
+	}
+
+	// Handle streaming response
+	if chatReq.Stream {
+		handleStreamingResponse(w, resp)
+		return
+	}
+
+	// Handle regular response
+	handleRegularResponse(w, resp, originalModel)
+}
+
+func handleStreamingResponse(w http.ResponseWriter, resp *http.Response) {
+	log.Printf("Starting streaming response handling")
+
+	// Set headers for streaming response
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(resp.StatusCode)
+
+	// Create a buffered reader for the response body
+	reader := bufio.NewReaderSize(resp.Body, 1024)
+
+	// Create a context that will be cancelled when the client disconnects
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a channel to detect client disconnection
+	clientGone := w.(http.CloseNotifier).CloseNotify()
+
+	// Create a channel for errors
+	errChan := make(chan error, 1)
+
+	// Start processing in a goroutine
+	go func() {
+		defer close(errChan)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-clientGone:
+				log.Printf("Client connection closed")
+				cancel()
+				return
+			default:
+				// Read until we get a complete SSE message
+				var buffer bytes.Buffer
+				for {
+					line, err := reader.ReadBytes('\n')
+					if err != nil {
+						if err == io.EOF {
+							log.Printf("EOF reached")
+							return
+						}
+						log.Printf("Error reading from response: %v", err)
+						errChan <- err
+						return
+					}
+
+					// Log the received line for debugging
+					log.Printf("Received line: %s", string(line))
+
+					// Write to buffer
+					buffer.Write(line)
+
+					// If we've reached the end of an event (double newline)
+					if bytes.HasSuffix(buffer.Bytes(), []byte("\n\n")) {
+						break
+					}
+				}
+
+				// Get the complete message
+				message := buffer.Bytes()
+
+				// Skip if empty
+				if len(bytes.TrimSpace(message)) == 0 {
+					continue
+				}
+
+				// Write the message
+				if _, err := w.Write(message); err != nil {
+					log.Printf("Error writing to client: %v", err)
+					errChan <- err
+					return
+				}
+
+				// Flush after each complete message
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+					log.Printf("Flushed message to client")
+				}
+			}
+		}
+	}()
+
+	// Wait for completion or error
+	select {
+	case err := <-errChan:
+		if err != nil {
+			log.Printf("Error in streaming response: %v", err)
+		}
+	case <-clientGone:
+		log.Printf("Client disconnected")
+	case <-ctx.Done():
+		log.Printf("Context cancelled")
+	}
+
+	log.Printf("Streaming response handler completed")
+}
+
+func handleRegularResponse(w http.ResponseWriter, resp *http.Response, originalModel string) {
+	log.Printf("Handling regular (non-streaming) response")
+	log.Printf("Response status: %d", resp.StatusCode)
+	log.Printf("Response headers: %+v", resp.Header)
+
+	// Read and log response body
+	body, err := readResponse(resp)
+	if err != nil {
+		log.Printf("Error reading response: %v", err)
+		http.Error(w, "Error reading response from upstream", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Original response body: %s", string(body))
+
+	// Parse the DeepSeek response
+	var deepseekResp deepseek.Response
+	if err := json.Unmarshal(body, &deepseekResp); err != nil {
+		log.Printf("Error parsing DeepSeek response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Use the original model name instead of hardcoding gpt-4o
+	deepseekResp.Model = originalModel
+
+	// If we have tools calls, make sure the have type "function"
+	for i, choice := range deepseekResp.Choices {
+		if choice.Message.ToolCalls != nil {
+			for j, tc := range choice.Message.ToolCalls {
+				tc.Type = "function"
+				choice.Message.ToolCalls[j] = tc
+			}
+			deepseekResp.Choices[i] = choice
+		}
+	}
+
+	// Convert back to JSON
+	modifiedBody, err := json.Marshal(deepseekResp)
+	if err != nil {
+		log.Printf("Error creating modified response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Modified response body: %s", string(modifiedBody))
+
+	// Set response headers
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	w.Write(modifiedBody)
+	log.Printf("Modified response sent successfully")
+}

--- a/internal/backend/openrouter/utils.go
+++ b/internal/backend/openrouter/utils.go
@@ -1,0 +1,56 @@
+package openrouter
+
+import (
+	"compress/flate"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/andybalholm/brotli"
+)
+
+func copyHeaders(dst, src http.Header) {
+	// Headers to skip
+	skipHeaders := map[string]bool{
+		"Content-Length":    true,
+		"Content-Encoding":  true,
+		"Transfer-Encoding": true,
+		"Connection":        true,
+	}
+
+	for k, vv := range src {
+		if !skipHeaders[k] {
+			for _, v := range vv {
+				dst.Add(k, v)
+			}
+		}
+	}
+}
+
+func readResponse(resp *http.Response) ([]byte, error) {
+	var reader io.Reader = resp.Body
+
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error creating gzip reader: %v", err)
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	case "br":
+		reader = brotli.NewReader(resp.Body)
+	case "deflate":
+		reader = flate.NewReader(resp.Body)
+	}
+
+	return io.ReadAll(reader)
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/proxy-ollama.go
+++ b/proxy-ollama.go
@@ -1,18 +1,12 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
-	"time"
 
-	ollama "github.com/danilofalcao/cursor-deepseek/internal/api/ollama/v1"
-	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend/ollama"
 	"github.com/joho/godotenv"
 	"golang.org/x/net/http2"
 )
@@ -23,53 +17,20 @@ const (
 	defaultModel = "deepseek-r1:14b"
 )
 
-// Configuration structure
-type Config struct {
-	endpoint string
-	model    string
-}
-
-var activeConfig Config
-
-func init() {
-	// Load .env file
-	log.Printf("Variant: OLLAMA")
-	if err := godotenv.Load(); err != nil {
-		log.Printf("Warning: .env file not found or error loading it: %v", err)
-	}
-
-	// Get custom Ollama endpoint if specified
-	customEndpoint := os.Getenv("OLLAMA_API_ENDPOINT")
-	if customEndpoint != "" {
-		activeConfig.endpoint = customEndpoint
-	} else {
-		activeConfig.endpoint = ollamaEndpoint
-	}
-
-	// Get custom Ollama endpoint if specified
-	modelenv := os.Getenv("DEFAULT_MODEL")
-	if modelenv != "" {
-		activeConfig.model = modelenv
-	} else {
-		//no environment set so check for command line argument
-		modelFlag := defaultModel // default value
-		for i, arg := range os.Args {
-			if arg == "-model" && i+1 < len(os.Args) {
-				modelFlag = os.Args[i+1]
-			}
-		}
-		activeConfig.model = modelFlag
-	}
-
-	log.Printf("Initialized with model: %s using endpoint: %s", activeConfig.model, activeConfig.endpoint)
+type handler struct {
+	b backend.Backend
 }
 
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 
+	h := handler{
+		b: initBackend(),
+	}
+
 	server := &http.Server{
 		Addr:    ":9000",
-		Handler: http.HandlerFunc(proxyHandler),
+		Handler: http.HandlerFunc(h.proxyHandler),
 	}
 
 	// Enable HTTP/2 support
@@ -81,6 +42,41 @@ func main() {
 	}
 }
 
+func initBackend() backend.Backend {
+	// Load .env file
+	log.Printf("Variant: OLLAMA")
+	if err := godotenv.Load(); err != nil {
+		log.Printf("Warning: .env file not found or error loading it: %v", err)
+	}
+
+	opts := ollama.Options{}
+	// Get custom Ollama endpoint if specified
+	customEndpoint := os.Getenv("OLLAMA_API_ENDPOINT")
+	if customEndpoint != "" {
+		opts.Endpoint = customEndpoint
+	} else {
+		opts.Endpoint = ollamaEndpoint
+	}
+
+	// Get custom Ollama endpoint if specified
+	modelenv := os.Getenv("DEFAULT_MODEL")
+	if modelenv != "" {
+		opts.Model = modelenv
+	} else {
+		//no environment set so check for command line argument
+		modelFlag := defaultModel // default value
+		for i, arg := range os.Args {
+			if arg == "-model" && i+1 < len(os.Args) {
+				modelFlag = os.Args[i+1]
+			}
+		}
+		opts.Model = modelFlag
+	}
+
+	return ollama.NewOllamaBackend(opts)
+
+}
+
 func enableCors(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
@@ -89,221 +85,22 @@ func enableCors(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }
 
-func proxyHandler(w http.ResponseWriter, r *http.Request) {
+func (h handler) proxyHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Received request: %s %s", r.Method, r.URL.Path)
-
-	if r.Method == "OPTIONS" {
-		enableCors(w)
-		return
-	}
 
 	enableCors(w)
 
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	switch r.URL.Path {
 	case "/v1/chat/completions":
-		handleChatCompletions(w, r)
+		h.b.HandleChatCompletions(w, r)
 	case "/v1/models":
-		handleModelsRequest(w)
+		h.b.HandleModelsRequest(w)
 	default:
 		http.Error(w, "Not found", http.StatusNotFound)
 	}
-}
-
-func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
-	var chatReq openai.ChatCompletionRequest
-	if err := json.NewDecoder(r.Body).Decode(&chatReq); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	log.Printf("chatReq: %+v", chatReq)
-
-	// Store original model name for response
-	originalModel := chatReq.Model
-	if originalModel == "" {
-		originalModel = activeConfig.model
-	}
-
-	// Always use the configured model internally
-	chatReq.Model = activeConfig.model
-	log.Printf("Model converted to: %s (original: %s)", activeConfig.model, originalModel)
-
-	// Convert to Ollama request format
-	ollamaReq := ollama.Request{
-		Model:    activeConfig.model,
-		Messages: convertMessages(chatReq.Messages),
-		Stream:   chatReq.Stream,
-	}
-
-	if chatReq.Temperature != nil {
-		ollamaReq.Temperature = *chatReq.Temperature
-	}
-	if chatReq.MaxTokens != nil {
-		ollamaReq.MaxTokens = *chatReq.MaxTokens
-	}
-
-	// Create Ollama request
-	ollamaReqBody, err := json.Marshal(ollamaReq)
-	if err != nil {
-		log.Printf("ERROR: failed to marshal ollama request: %s", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("ollamaReqBody: %s", string(ollamaReqBody))
-	// Send request to Ollama
-	ollamaResp, err := http.Post(
-		fmt.Sprintf("%s/chat", activeConfig.endpoint),
-		"application/json",
-		bytes.NewBuffer(ollamaReqBody),
-	)
-	if err != nil {
-		log.Printf("ERROR: POST failed: %s", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	defer ollamaResp.Body.Close()
-
-	if chatReq.Stream {
-		handleStreamingResponse(w, r, ollamaResp, originalModel)
-	} else {
-		handleRegularResponse(w, ollamaResp, originalModel)
-	}
-}
-
-func convertMessages(messages []openai.Message) []ollama.Message {
-	ollamaMessages := make([]ollama.Message, len(messages))
-	for i, message := range messages {
-		var content string
-		switch message.GetContent().(type) {
-		case openai.Content_String:
-			content = message.GetContentString()
-		case openai.Content_Array:
-			contentArray := message.GetContentArray()
-			for i := range contentArray {
-				t := contentArray.GetContentPartTextAtIndex(i).Text
-				if t != "" {
-					content += "; " + t
-				}
-			}
-		}
-		ollamaMessages[i] = ollama.Message{
-			Role:    message.Role,
-			Content: content,
-		}
-	}
-	return ollamaMessages
-}
-
-func handleStreamingResponse(w http.ResponseWriter, r *http.Request, resp *http.Response, originalModel string) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
-		return
-	}
-
-	reader := bufio.NewReader(resp.Body)
-	for {
-		line, err := reader.ReadBytes('\n')
-		if err != nil {
-			if err != io.EOF {
-				log.Printf("Error reading stream: %v", err)
-			}
-			break
-		}
-
-		var ollamaResp ollama.Response
-		if err := json.Unmarshal(line, &ollamaResp); err != nil {
-			log.Printf("Error unmarshaling response: %v", err)
-			continue
-		}
-
-		openAIResp := openai.ChatCompletionStreamResponse{
-			ID:      "chatcmpl-" + time.Now().Format("20060102150405"),
-			Object:  "chat.completion.chunk",
-			Created: time.Now().Unix(),
-			Model:   originalModel,
-			Choices: []openai.StreamChoice{
-				{
-					Index: 0,
-					Delta: openai.Delta{
-						Content: openai.Content_String{Content: ollamaResp.Message.Content},
-						Role:    "assistant",
-					},
-				},
-			},
-		}
-
-		if ollamaResp.Done {
-			openAIResp.Choices[0].FinishReason = "stop"
-		}
-
-		if data, err := json.Marshal(openAIResp); err == nil {
-			log.Printf("data: %+v", string(data))
-			fmt.Fprintf(w, "data: %s\n\n", data)
-			flusher.Flush()
-		} else {
-			log.Printf("ERROR: failed to marshal openAIResp: %s", err.Error())
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if ollamaResp.Done {
-			break
-		}
-	}
-}
-
-func handleRegularResponse(w http.ResponseWriter, resp *http.Response, originalModel string) {
-	var ollamaResp ollama.Response
-	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// Convert to OpenAI format
-	openAIResp := openai.ChatCompletionResponse{
-		ID:      "chatcmpl-" + time.Now().Format("20060102150405"),
-		Object:  "chat.completion",
-		Created: time.Now().Unix(),
-		Model:   originalModel,
-		Choices: []openai.Choice{
-			{
-				Index: 0,
-				Message: openai.Message{
-					Role:    "assistant",
-					Content: openai.Content_String{Content: ollamaResp.Message.Content},
-				},
-				FinishReason: "stop",
-			},
-		},
-	}
-
-	log.Printf("openAIResp: %+v", openAIResp)
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(openAIResp)
-}
-
-func handleModelsRequest(w http.ResponseWriter) {
-	log.Printf("Handling models request")
-
-	response := openai.ModelsResponse{
-		Object: "list",
-		Data: []openai.Model{
-			{
-				ID:      activeConfig.model,
-				Object:  "model",
-				Created: time.Now().Unix(),
-				OwnedBy: "ollama",
-			},
-		},
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
-	log.Printf("Models response sent successfully")
 }

--- a/proxy-openrouter.go
+++ b/proxy-openrouter.go
@@ -1,156 +1,48 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
-	"compress/flate"
-	"compress/gzip"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
-	"github.com/andybalholm/brotli"
-	deepseek "github.com/danilofalcao/cursor-deepseek/internal/api/deepseek/v1"
-	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend/openrouter"
 	"github.com/joho/godotenv"
 	"golang.org/x/net/http2"
 )
 
-const (
-	openRouterEndpoint = "https://openrouter.ai/api/v1"
-	defaultChatModel   = "deepseek/deepseek-chat"
-)
-
-var openRouterAPIKey string
-
-func init() {
-	// Load .env file
-	if err := godotenv.Load(); err != nil {
-		log.Printf("Warning: .env file not found or error loading it: %v", err)
-	}
-
-	// Get OpenRouter API key
-	openRouterAPIKey = os.Getenv("OPENROUTER_API_KEY")
-	if openRouterAPIKey == "" {
-		log.Fatal("OPENROUTER_API_KEY environment variable is required")
-	}
-}
-
-func convertToolChoice(choice interface{}) string {
-	if choice == nil {
-		return ""
-	}
-
-	// If string "auto" or "none"
-	if str, ok := choice.(string); ok {
-		switch str {
-		case "auto", "none":
-			return str
-		}
-	}
-
-	// Try to parse as map for function call
-	if choiceMap, ok := choice.(map[string]interface{}); ok {
-		if choiceMap["type"] == "function" {
-			return "auto" // DeepSeek doesn't support specific function selection, default to auto
-		}
-	}
-
-	return ""
-}
-
-func convertToolCalls(toolCalls []openai.ToolCall, toolType string) []deepseek.ToolCall {
-	getToolType := func(toolCall openai.ToolCall) string {
-		if toolType != "" {
-			return toolType
-		}
-		return toolCall.Type
-	}
-	converted := make([]deepseek.ToolCall, len(toolCalls))
-	for i, tc := range toolCalls {
-		converted[i] = deepseek.ToolCall{
-			ID:   tc.ID,
-			Type: getToolType(tc),
-			Function: deepseek.ToolCallFunction{
-				Name:      tc.Function.Name,
-				Arguments: tc.Function.Arguments,
-			},
-		}
-	}
-	return converted
-}
-
-func convertMessages(messages []openai.Message) []deepseek.Message {
-	converted := make([]deepseek.Message, len(messages))
-	for i, msg := range messages {
-		log.Printf("Converting message %d - Role: %s", i, msg.Role)
-		var content string
-		switch msg.GetContent().(type) {
-		case openai.Content_String:
-			content = msg.GetContentString()
-		case openai.Content_Array:
-			contentArray := msg.GetContentArray()
-			for i := range contentArray {
-				t := contentArray.GetContentPartTextAtIndex(i).Text
-				if t != "" {
-					content += "; " + t
-				}
-			}
-		}
-		converted[i] = deepseek.Message{
-			Role:       msg.Role,
-			Content:    content,
-			ToolCallID: msg.ToolCallID,
-			Name:       msg.Name,
-		}
-
-		// Convert function role to tool role
-		if msg.Role == "function" {
-			converted[i].Role = "tool"
-			converted[i].ToolCalls = convertToolCalls(msg.ToolCalls, "")
-			log.Printf("Converted function role to tool role")
-		}
-
-		// Handle assistant messages with tool calls
-		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-			log.Printf("Processing assistant message with %d tool calls", len(msg.ToolCalls))
-
-			// Ensure tool calls are properly formatted
-			converted[i].ToolCalls = convertToolCalls(msg.ToolCalls, "function")
-		}
-
-		// Handle tool response messages
-		if msg.Role == "tool" || msg.Role == "function" {
-			log.Printf("Processing tool/function response message")
-			converted[i].Role = "tool"
-			if msg.Name != "" {
-				log.Printf("Tool response from function: %s", msg.Name)
-			}
-		}
-	}
-
-	return converted
-}
-
-func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
+type handler struct {
+	b      backend.Backend
+	apikey string
 }
 
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 
+	// Load .env file
+	if err := godotenv.Load(); err != nil {
+		log.Printf("Warning: .env file not found or error loading it: %v", err)
+	}
+
+	opts := openrouter.Options{
+		Endpoint: "https://openrouter.ai/api/v1",
+		Model:    "deepseek/deepseek-chat",
+	}
+	// Get OpenRouter API key
+	opts.ApiKey = os.Getenv("OPENROUTER_API_KEY")
+	if opts.ApiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required")
+	}
+
+	h := handler{
+		b:      openrouter.NewOpenrouterBackend(opts),
+		apikey: opts.ApiKey,
+	}
+
 	server := &http.Server{
 		Addr:    ":9000",
-		Handler: http.HandlerFunc(proxyHandler),
+		Handler: http.HandlerFunc(h.proxyHandler),
 	}
 
 	// Enable HTTP/2 support
@@ -170,15 +62,15 @@ func enableCors(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }
 
-func proxyHandler(w http.ResponseWriter, r *http.Request) {
+func (h handler) proxyHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Received request: %s %s", r.Method, r.URL.Path)
 
+	enableCors(w)
+
 	if r.Method == "OPTIONS" {
-		enableCors(w, r)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
-
-	enableCors(w, r)
 
 	// Validate API key
 	authHeader := r.Header.Get("Authorization")
@@ -189,455 +81,19 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userAPIKey := strings.TrimPrefix(authHeader, "Bearer ")
-	if userAPIKey != openRouterAPIKey {
+	if userAPIKey != h.apikey {
 		log.Printf("Invalid API key provided")
-		http.Error(w, "Invalid API key", http.StatusUnauthorized)
+		http.Error(w, "Invalid API key", http.StatusForbidden)
 		return
 	}
 
-	// Handle /v1/models endpoint
-	if r.URL.Path == "/v1/models" && r.Method == "GET" {
-		log.Printf("Handling /v1/models request")
-		handleModelsRequest(w)
-		return
-	}
-
-	// Log headers for debugging
-	log.Printf("Request headers: %+v", r.Header)
-
-	// Only handle chat completions API requests
-	if r.URL.Path != "/v1/chat/completions" {
-		log.Printf("Invalid path: %s", r.URL.Path)
-		http.Error(w, "Only /v1/chat/completions endpoint is supported", http.StatusNotFound)
-		return
-	}
-
-	// Read and log request body for debugging
-	var chatReq openai.ChatCompletionRequest
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("Error reading request body: %v", err)
-		http.Error(w, "Error reading request", http.StatusBadRequest)
-		return
-	}
-	r.Body = io.NopCloser(bytes.NewBuffer(body))
-
-	if err := json.Unmarshal(body, &chatReq); err != nil {
-		log.Printf("Error parsing request JSON: %v", err)
-		log.Printf("Raw request body: %s", string(body))
-		http.Error(w, "Invalid JSON", http.StatusBadRequest)
-		return
-	}
-
-	log.Printf("Parsed request: %+v", chatReq)
-
-	// Handle models endpoint
-	if r.URL.Path == "/v1/models" {
-		handleModelsRequest(w)
-		return
-	}
-
-	// Only handle API requests with /v1/ prefix
-	if !strings.HasPrefix(r.URL.Path, "/v1/") {
-		log.Printf("Invalid path: %s", r.URL.Path)
+	switch r.URL.Path {
+	case "/v1/chat/completions":
+		h.b.HandleChatCompletions(w, r)
+	case "/v1/models":
+		h.b.HandleModelsRequest(w)
+	default:
 		http.Error(w, "Not found", http.StatusNotFound)
-		return
 	}
 
-	// Restore the body for further reading
-	r.Body = io.NopCloser(bytes.NewBuffer(body))
-
-	log.Printf("Request body: %s", string(body))
-
-	// Parse the request to check for streaming - reuse existing chatReq
-	if err := json.Unmarshal(body, &chatReq); err != nil {
-		log.Printf("Error parsing request JSON: %v", err)
-		http.Error(w, "Error parsing request", http.StatusBadRequest)
-		return
-	}
-
-	log.Printf("Requested model: %s", chatReq.Model)
-
-	// Store original model name for response
-	originalModel := chatReq.Model
-
-	// Convert to deepseek-chat internally
-	chatReq.Model = defaultChatModel
-	log.Printf("Model converted to: %s (original: %s)", defaultChatModel, originalModel)
-
-	// Convert to DeepSeek request format
-	deepseekReq := deepseek.Request{
-		Model:    defaultChatModel,
-		Messages: convertMessages(chatReq.Messages),
-		Stream:   chatReq.Stream,
-	}
-
-	// Set default temperature if not provided
-	if chatReq.Temperature != nil {
-		deepseekReq.Temperature = *chatReq.Temperature
-	} else {
-		defaultTemp := 0.7
-		deepseekReq.Temperature = defaultTemp
-	}
-
-	// Set default max tokens if not provided
-	if chatReq.MaxTokens != nil {
-		deepseekReq.MaxTokens = *chatReq.MaxTokens
-	} else {
-		defaultMaxTokens := 4096
-		deepseekReq.MaxTokens = defaultMaxTokens
-	}
-
-	// Handle tools and tool choice
-	if len(chatReq.Tools) > 0 {
-		deepseekReq.Tools = convertTools(chatReq.Tools)
-		deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
-	} else if len(chatReq.Functions) > 0 {
-		// Convert legacy functions to tools
-		tools := make([]deepseek.Tool, len(chatReq.Functions))
-		for i, fn := range chatReq.Functions {
-			tools[i] = deepseek.Tool{
-				Type: "function",
-				Function: deepseek.Function{
-					Name:        fn.Name,
-					Parameters:  fn.Parameters,
-					Description: fn.Description,
-				},
-			}
-		}
-		deepseekReq.Tools = tools
-		deepseekReq.ToolChoice = convertToolChoice(chatReq.ToolChoice)
-	}
-
-	// Create new request body
-	modifiedBody, err := json.Marshal(deepseekReq)
-	if err != nil {
-		log.Printf("Error creating modified request body: %v", err)
-		http.Error(w, "Error creating modified request", http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Modified request body: %s", string(modifiedBody))
-
-	// Create the proxy request to OpenRouter
-	targetURL := openRouterEndpoint + "/chat/completions"
-	if r.URL.RawQuery != "" {
-		targetURL += "?" + r.URL.RawQuery
-	}
-
-	log.Printf("Forwarding to: %s", targetURL)
-	proxyReq, err := http.NewRequest(r.Method, targetURL, bytes.NewReader(modifiedBody))
-	if err != nil {
-		log.Printf("Error creating proxy request: %v", err)
-		http.Error(w, "Error creating proxy request", http.StatusInternalServerError)
-		return
-	}
-
-	// Copy headers
-	copyHeaders(proxyReq.Header, r.Header)
-
-	// Set OpenRouter API key and required headers
-	proxyReq.Header.Set("Authorization", "Bearer "+openRouterAPIKey)
-	proxyReq.Header.Set("Content-Type", "application/json")
-	proxyReq.Header.Set("HTTP-Referer", "https://github.com/danilofalcao/cursor-deepseek") // Optional, for OpenRouter rankings
-	proxyReq.Header.Set("X-Title", "Cursor DeepSeek")                                      // Optional, for OpenRouter rankings
-	if chatReq.Stream {
-		proxyReq.Header.Set("Accept", "text/event-stream")
-	}
-
-	// Add Accept-Language header from request
-	if acceptLanguage := r.Header.Get("Accept-Language"); acceptLanguage != "" {
-		proxyReq.Header.Set("Accept-Language", acceptLanguage)
-	}
-
-	log.Printf("Proxy request headers: %v", proxyReq.Header)
-
-	// Create a custom client with keepalive
-	client := &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLS:   nil,
-		},
-		// Remove global timeout as we'll handle timeouts per request type
-		Timeout: 0,
-	}
-
-	// Create context with timeout based on streaming
-	ctx := context.Background()
-	if !chatReq.Stream {
-		// Use timeout only for non-streaming requests
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 5*time.Minute)
-		defer cancel()
-	}
-
-	// Create the request with context
-	proxyReq = proxyReq.WithContext(ctx)
-
-	// Send the request
-	resp, err := client.Do(proxyReq)
-	if err != nil {
-		log.Printf("Error forwarding request: %v", err)
-		http.Error(w, "Error forwarding request", http.StatusBadGateway)
-		return
-	}
-	defer resp.Body.Close()
-
-	log.Printf("OpenRouter response status: %d", resp.StatusCode)
-	log.Printf("OpenRouter response headers: %v", resp.Header)
-
-	// Handle error responses
-	if resp.StatusCode >= 400 {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Error reading error response: %v", err)
-			http.Error(w, "Error reading response", http.StatusInternalServerError)
-			return
-		}
-		log.Printf("OpenRouter error response: %s", string(respBody))
-
-		// Forward the error response
-		for k, v := range resp.Header {
-			w.Header()[k] = v
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(resp.StatusCode)
-		w.Write(respBody)
-		return
-	}
-
-	// Handle streaming response
-	if chatReq.Stream {
-		handleStreamingResponse(w, resp)
-		return
-	}
-
-	// Handle regular response
-	handleRegularResponse(w, resp, originalModel)
-}
-
-func convertTools(tools []openai.Tool) []deepseek.Tool {
-	converted := make([]deepseek.Tool, len(tools))
-	for i, tool := range tools {
-		converted[i] = deepseek.Tool{
-			Type: tool.Type,
-			Function: deepseek.Function{
-				Name:        tool.Function.Name,
-				Parameters:  tool.Function.Parameters,
-				Description: tool.Function.Description,
-			},
-		}
-	}
-	return converted
-}
-
-func handleStreamingResponse(w http.ResponseWriter, resp *http.Response) {
-	log.Printf("Starting streaming response handling")
-
-	// Set headers for streaming response
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(resp.StatusCode)
-
-	// Create a buffered reader for the response body
-	reader := bufio.NewReaderSize(resp.Body, 1024)
-
-	// Create a context that will be cancelled when the client disconnects
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Create a channel to detect client disconnection
-	clientGone := w.(http.CloseNotifier).CloseNotify()
-
-	// Create a channel for errors
-	errChan := make(chan error, 1)
-
-	// Start processing in a goroutine
-	go func() {
-		defer close(errChan)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-clientGone:
-				log.Printf("Client connection closed")
-				cancel()
-				return
-			default:
-				// Read until we get a complete SSE message
-				var buffer bytes.Buffer
-				for {
-					line, err := reader.ReadBytes('\n')
-					if err != nil {
-						if err == io.EOF {
-							log.Printf("EOF reached")
-							return
-						}
-						log.Printf("Error reading from response: %v", err)
-						errChan <- err
-						return
-					}
-
-					// Log the received line for debugging
-					log.Printf("Received line: %s", string(line))
-
-					// Write to buffer
-					buffer.Write(line)
-
-					// If we've reached the end of an event (double newline)
-					if bytes.HasSuffix(buffer.Bytes(), []byte("\n\n")) {
-						break
-					}
-				}
-
-				// Get the complete message
-				message := buffer.Bytes()
-
-				// Skip if empty
-				if len(bytes.TrimSpace(message)) == 0 {
-					continue
-				}
-
-				// Write the message
-				if _, err := w.Write(message); err != nil {
-					log.Printf("Error writing to client: %v", err)
-					errChan <- err
-					return
-				}
-
-				// Flush after each complete message
-				if f, ok := w.(http.Flusher); ok {
-					f.Flush()
-					log.Printf("Flushed message to client")
-				}
-			}
-		}
-	}()
-
-	// Wait for completion or error
-	select {
-	case err := <-errChan:
-		if err != nil {
-			log.Printf("Error in streaming response: %v", err)
-		}
-	case <-clientGone:
-		log.Printf("Client disconnected")
-	case <-ctx.Done():
-		log.Printf("Context cancelled")
-	}
-
-	log.Printf("Streaming response handler completed")
-}
-
-func handleRegularResponse(w http.ResponseWriter, resp *http.Response, originalModel string) {
-	log.Printf("Handling regular (non-streaming) response")
-	log.Printf("Response status: %d", resp.StatusCode)
-	log.Printf("Response headers: %+v", resp.Header)
-
-	// Read and log response body
-	body, err := readResponse(resp)
-	if err != nil {
-		log.Printf("Error reading response: %v", err)
-		http.Error(w, "Error reading response from upstream", http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Original response body: %s", string(body))
-
-	// Parse the DeepSeek response
-	var deepseekResp deepseek.Response
-	if err := json.Unmarshal(body, &deepseekResp); err != nil {
-		log.Printf("Error parsing DeepSeek response: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	// Use the original model name instead of hardcoding gpt-4o
-	deepseekResp.Model = originalModel
-
-	// If we have tools calls, make sure the have type "function"
-	for i, choice := range deepseekResp.Choices {
-		if choice.Message.ToolCalls != nil {
-			for j, tc := range choice.Message.ToolCalls {
-				tc.Type = "function"
-				choice.Message.ToolCalls[j] = tc
-			}
-			deepseekResp.Choices[i] = choice
-		}
-	}
-
-	// Convert back to JSON
-	modifiedBody, err := json.Marshal(deepseekResp)
-	if err != nil {
-		log.Printf("Error creating modified response: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Modified response body: %s", string(modifiedBody))
-
-	// Set response headers
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(resp.StatusCode)
-	w.Write(modifiedBody)
-	log.Printf("Modified response sent successfully")
-}
-
-func copyHeaders(dst, src http.Header) {
-	// Headers to skip
-	skipHeaders := map[string]bool{
-		"Content-Length":    true,
-		"Content-Encoding":  true,
-		"Transfer-Encoding": true,
-		"Connection":        true,
-	}
-
-	for k, vv := range src {
-		if !skipHeaders[k] {
-			for _, v := range vv {
-				dst.Add(k, v)
-			}
-		}
-	}
-}
-
-func handleModelsRequest(w http.ResponseWriter) {
-	log.Printf("Handling models request")
-
-	response := openai.ModelsResponse{
-		Object: "list",
-		Data: []openai.Model{
-			{
-				ID:      defaultChatModel,
-				Object:  "model",
-				Created: time.Now().Unix(),
-				OwnedBy: "deepseek",
-			},
-		},
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
-	log.Printf("Models response sent successfully")
-}
-
-func readResponse(resp *http.Response) ([]byte, error) {
-	var reader io.Reader = resp.Body
-
-	switch resp.Header.Get("Content-Encoding") {
-	case "gzip":
-		gzReader, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error creating gzip reader: %v", err)
-		}
-		defer gzReader.Close()
-		reader = gzReader
-	case "br":
-		reader = brotli.NewReader(resp.Body)
-	case "deflate":
-		reader = flate.NewReader(resp.Body)
-	}
-
-	return io.ReadAll(reader)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -1,23 +1,13 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
-	"compress/flate"
-	"compress/gzip"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
-	"github.com/andybalholm/brotli"
-	deepseek "github.com/danilofalcao/cursor-deepseek/internal/api/deepseek/v1"
-	openai "github.com/danilofalcao/cursor-deepseek/internal/api/openai/v1"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend"
+	"github.com/danilofalcao/cursor-deepseek/internal/backend/deepseek"
 	"github.com/joho/godotenv"
 	"golang.org/x/net/http2"
 )
@@ -27,28 +17,29 @@ const (
 	deepseekBetaEndpoint = "https://api.deepseek.com/beta"
 	deepseekChatModel    = "deepseek-chat"
 	deepseekCoderModel   = "deepseek-coder"
-	gpt4oModel           = "gpt-4o"
 )
 
-var deepseekAPIKey string
-
-// Configuration structure
-type Config struct {
-	endpoint string
-	model    string
+type handler struct {
+	b      backend.Backend
+	apikey string
 }
 
-var activeConfig Config
+func main() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 
-func init() {
 	// Load .env file
 	if err := godotenv.Load(); err != nil {
 		log.Printf("Warning: .env file not found or error loading it: %v", err)
 	}
 
+	opts := deepseek.Options{
+		Endpoint: deepseekEndpoint,
+		Model:    deepseekChatModel,
+	}
+
 	// Get DeepSeek API key
-	deepseekAPIKey = os.Getenv("DEEPSEEK_API_KEY")
-	if deepseekAPIKey == "" {
+	opts.ApiKey = os.Getenv("DEEPSEEK_API_KEY")
+	if opts.ApiKey == "" {
 		log.Fatal("DEEPSEEK_API_KEY environment variable is required")
 	}
 
@@ -63,130 +54,22 @@ func init() {
 	// Configure the active endpoint and model based on the flag
 	switch modelFlag {
 	case "coder":
-		activeConfig = Config{
-			endpoint: deepseekBetaEndpoint,
-			model:    deepseekCoderModel,
-		}
-	case "chat":
-		activeConfig = Config{
-			endpoint: deepseekEndpoint,
-			model:    deepseekChatModel,
-		}
+		opts.Endpoint = deepseekBetaEndpoint
+		opts.Model = deepseekCoderModel
 	default:
 		log.Printf("Invalid model specified: %s. Using default chat model.", modelFlag)
-		activeConfig = Config{
-			endpoint: deepseekEndpoint,
-			model:    deepseekChatModel,
-		}
 	}
 
-	log.Printf("Initialized with model: %s using endpoint: %s", activeConfig.model, activeConfig.endpoint)
-}
+	log.Printf("Initialized with model: %s using endpoint: %s", opts.Model, opts.Endpoint)
 
-// OpenAI compatible request structure
-type ChatRequest = openai.ChatCompletionRequest
-
-func convertToolChoice(choice interface{}) string {
-	if choice == nil {
-		return ""
+	h := handler{
+		b:      deepseek.NewDeepseekBackend(opts),
+		apikey: opts.ApiKey,
 	}
-
-	// If string "auto" or "none"
-	if str, ok := choice.(string); ok {
-		switch str {
-		case "auto", "none":
-			return str
-		}
-	}
-
-	// Try to parse as map for function call
-	if choiceMap, ok := choice.(map[string]interface{}); ok {
-		if choiceMap["type"] == "function" {
-			return "auto" // DeepSeek doesn't support specific function selection, default to auto
-		}
-	}
-
-	return ""
-}
-
-func convertMessages(messages []openai.Message) []deepseek.Message {
-	converted := make([]deepseek.Message, len(messages))
-	for i, msg := range messages {
-		log.Printf("Converting message %d - Role: %s", i, msg.Role)
-		var content string
-		switch msg.GetContent().(type) {
-		case openai.Content_String:
-			content = msg.GetContentString()
-		case openai.Content_Array:
-			contentArray := msg.GetContentArray()
-			for i := range contentArray {
-				t := contentArray.GetContentPartTextAtIndex(i).Text
-				if t != "" {
-					content += "; " + t
-				}
-			}
-		}
-		converted[i] = deepseek.Message{
-			Role:       msg.Role,
-			Content:    content,
-			ToolCallID: msg.ToolCallID,
-			Name:       msg.Name,
-		}
-
-		// Handle assistant messages with tool calls
-		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-			log.Printf("Processing assistant message with %d tool calls", len(msg.ToolCalls))
-			// DeepSeek expects tool_calls in a specific format
-			toolCalls := make([]deepseek.ToolCall, len(msg.ToolCalls))
-			for j, tc := range msg.ToolCalls {
-				toolCalls[j] = deepseek.ToolCall{
-					ID:   tc.ID,
-					Type: "function",
-					Function: deepseek.ToolCallFunction{
-						Name:      tc.Function.Name,
-						Arguments: tc.Function.Arguments,
-					},
-				}
-				log.Printf("Tool call %d - ID: %s, Function: %s", j, tc.ID, tc.Function.Name)
-			}
-			converted[i].ToolCalls = toolCalls
-		}
-
-		// Handle function response messages
-		if msg.Role == "function" {
-			log.Printf("Converting function response to tool response")
-			// Convert to tool response format
-			converted[i].Role = "tool"
-		}
-	}
-
-	// Log the final converted messages
-	for i, msg := range converted {
-		log.Printf("Final message %d - Role: %s, Content: %s", i, msg.Role, truncateString(msg.Content, 50))
-		if len(msg.ToolCalls) > 0 {
-			log.Printf("Message %d has %d tool calls", i, len(msg.ToolCalls))
-		}
-	}
-
-	return converted
-}
-
-func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
-}
-
-// DeepSeek request structure
-type DeepSeekRequest = deepseek.Request
-
-func main() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 
 	server := &http.Server{
 		Addr:    ":9000",
-		Handler: http.HandlerFunc(proxyHandler),
+		Handler: http.HandlerFunc(h.proxyHandler),
 	}
 
 	// Enable HTTP/2 support
@@ -206,15 +89,15 @@ func enableCors(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }
 
-func proxyHandler(w http.ResponseWriter, r *http.Request) {
+func (h handler) proxyHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Received request: %s %s", r.Method, r.URL.Path)
 
+	enableCors(w)
+
 	if r.Method == "OPTIONS" {
-		enableCors(w)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
-
-	enableCors(w)
 
 	// Validate API key
 	authHeader := r.Header.Get("Authorization")
@@ -225,457 +108,18 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userAPIKey := strings.TrimPrefix(authHeader, "Bearer ")
-	if userAPIKey != deepseekAPIKey {
+	if userAPIKey != h.apikey {
 		log.Printf("Invalid API key provided")
-		http.Error(w, "Invalid API key", http.StatusUnauthorized)
+		http.Error(w, "Invalid API key", http.StatusForbidden)
 		return
 	}
 
-	// Handle /v1/models endpoint
-	if r.URL.Path == "/v1/models" && r.Method == "GET" {
-		log.Printf("Handling /v1/models request")
-		handleModelsRequest(w)
-		return
-	}
-
-	// Log headers for debugging
-	log.Printf("Request headers: %+v", r.Header)
-
-	// Read and log request body for debugging
-	var chatReq ChatRequest
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("Error reading request body: %v", err)
-		http.Error(w, "Error reading request", http.StatusBadRequest)
-		return
-	}
-	r.Body = io.NopCloser(bytes.NewBuffer(body))
-
-	if err := json.Unmarshal(body, &chatReq); err != nil {
-		log.Printf("Error parsing request JSON: %v", err)
-		log.Printf("Raw request body: %s", string(body))
-		http.Error(w, "Invalid JSON", http.StatusBadRequest)
-		return
-	}
-
-	log.Printf("Parsed request: %+v", chatReq)
-
-	// Handle models endpoint
-	if r.URL.Path == "/v1/models" {
-		handleModelsRequest(w)
-		return
-	}
-
-	// Only handle API requests with /v1/ prefix
-	if !strings.HasPrefix(r.URL.Path, "/v1/") {
-		log.Printf("Invalid path: %s", r.URL.Path)
+	switch r.URL.Path {
+	case "/v1/chat/completions":
+		h.b.HandleChatCompletions(w, r)
+	case "/v1/models":
+		h.b.HandleModelsRequest(w)
+	default:
 		http.Error(w, "Not found", http.StatusNotFound)
-		return
 	}
-
-	// Restore the body for further reading
-	r.Body = io.NopCloser(bytes.NewBuffer(body))
-
-	log.Printf("Request body: %s", string(body))
-
-	// Parse the request to check for streaming - reuse existing chatReq
-	if err := json.Unmarshal(body, &chatReq); err != nil {
-		log.Printf("Error parsing request JSON: %v", err)
-		http.Error(w, "Error parsing request", http.StatusBadRequest)
-		return
-	}
-
-	log.Printf("Requested model: %s", chatReq.Model)
-
-	// Store original model name for response
-	originalModel := chatReq.Model
-
-	// Convert to deepseek-chat internally
-	chatReq.Model = deepseekChatModel
-	log.Printf("Model converted to: %s (original: %s)", deepseekChatModel, originalModel)
-
-	// Convert to DeepSeek request format
-	deepseekReq := deepseek.Request{
-		Model:    deepseekChatModel,
-		Messages: convertMessages(chatReq.Messages),
-		Stream:   chatReq.Stream,
-	}
-
-	// Copy optional parameters if present
-	if chatReq.Temperature != nil {
-		deepseekReq.Temperature = *chatReq.Temperature
-	}
-	if chatReq.MaxTokens != nil {
-		deepseekReq.MaxTokens = *chatReq.MaxTokens
-	}
-
-	// Handle tools/functions
-	if len(chatReq.Tools) > 0 {
-		deepseekReq.Tools = convertTools(chatReq.Tools)
-		if tc := convertToolChoice(chatReq.ToolChoice); tc != "" {
-			deepseekReq.ToolChoice = tc
-		}
-	} else if len(chatReq.Functions) > 0 {
-		// Convert functions to tools format
-		tools := make([]deepseek.Tool, len(chatReq.Functions))
-		for i, fn := range chatReq.Functions {
-			tools[i] = deepseek.Tool{
-				Type: "function",
-				Function: deepseek.Function{
-					Name:        fn.Name,
-					Description: fn.Description,
-					Parameters:  fn.Parameters,
-				},
-			}
-		}
-		deepseekReq.Tools = tools
-
-		// Convert tool_choice if present
-		if tc := convertToolChoice(chatReq.ToolChoice); tc != "" {
-			deepseekReq.ToolChoice = tc
-		}
-	}
-
-	// Create new request body
-	modifiedBody, err := json.Marshal(deepseekReq)
-	if err != nil {
-		log.Printf("Error creating modified request body: %v", err)
-		http.Error(w, "Error creating modified request", http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Modified request body: %s", string(modifiedBody))
-
-	// Create the proxy request to DeepSeek
-	targetURL := activeConfig.endpoint + r.URL.Path
-	if r.URL.RawQuery != "" {
-		targetURL += "?" + r.URL.RawQuery
-	}
-
-	log.Printf("Forwarding to: %s", targetURL)
-	proxyReq, err := http.NewRequest(r.Method, targetURL, bytes.NewReader(modifiedBody))
-	if err != nil {
-		log.Printf("Error creating proxy request: %v", err)
-		http.Error(w, "Error creating proxy request", http.StatusInternalServerError)
-		return
-	}
-
-	// Copy headers
-	copyHeaders(proxyReq.Header, r.Header)
-
-	// Set DeepSeek API key and content type
-	proxyReq.Header.Set("Authorization", "Bearer "+deepseekAPIKey)
-	proxyReq.Header.Set("Content-Type", "application/json")
-	if chatReq.Stream {
-		proxyReq.Header.Set("Accept", "text/event-stream")
-	}
-
-	// Add Accept-Language header from request
-	if acceptLanguage := r.Header.Get("Accept-Language"); acceptLanguage != "" {
-		proxyReq.Header.Set("Accept-Language", acceptLanguage)
-	}
-
-	log.Printf("Proxy request headers: %v", proxyReq.Header)
-
-	// Create a custom client with keepalive
-	client := &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLS:   nil,
-		},
-		Timeout: 5 * time.Minute,
-	}
-
-	// Send the request
-	resp, err := client.Do(proxyReq)
-	if err != nil {
-		log.Printf("Error forwarding request: %v", err)
-		http.Error(w, "Error forwarding request", http.StatusBadGateway)
-		return
-	}
-	defer resp.Body.Close()
-
-	log.Printf("DeepSeek response status: %d", resp.StatusCode)
-	log.Printf("DeepSeek response headers: %v", resp.Header)
-
-	// Handle error responses
-	if resp.StatusCode >= 400 {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Error reading error response: %v", err)
-			http.Error(w, "Error reading response", http.StatusInternalServerError)
-			return
-		}
-		log.Printf("DeepSeek error response: %s", string(respBody))
-
-		// Forward the error response
-		for k, v := range resp.Header {
-			w.Header()[k] = v
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(resp.StatusCode)
-		w.Write(respBody)
-		return
-	}
-
-	// Handle streaming response
-	if chatReq.Stream {
-		handleStreamingResponse(w, r, resp, originalModel)
-		return
-	}
-
-	// Handle regular response
-	handleRegularResponse(w, resp, originalModel)
-}
-
-func convertTools(tools []openai.Tool) []deepseek.Tool {
-	converted := make([]deepseek.Tool, len(tools))
-	for i, tool := range tools {
-		converted[i] = deepseek.Tool{
-			Type: tool.Type,
-			Function: deepseek.Function{
-				Name:        tool.Function.Name,
-				Parameters:  tool.Function.Parameters,
-				Description: tool.Function.Description,
-			},
-		}
-	}
-	return converted
-}
-
-func handleStreamingResponse(w http.ResponseWriter, r *http.Request, resp *http.Response, originalModel string) {
-	log.Printf("Starting streaming response handling with model: %s", originalModel)
-	log.Printf("Response status: %d", resp.StatusCode)
-	log.Printf("Response headers: %+v", resp.Header)
-
-	// Set headers for streaming response
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(resp.StatusCode)
-
-	// Create a buffered reader for the response body
-	reader := bufio.NewReader(resp.Body)
-
-	// Create a context with cancel for cleanup
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-
-	// Start a goroutine to send heartbeats
-	go func() {
-		ticker := time.NewTicker(15 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				// Send a heartbeat comment
-				if _, err := w.Write([]byte(": heartbeat\n\n")); err != nil {
-					log.Printf("Error sending heartbeat: %v", err)
-					cancel()
-					return
-				}
-				if f, ok := w.(http.Flusher); ok {
-					f.Flush()
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Printf("Context cancelled, ending stream")
-			return
-		default:
-			line, err := reader.ReadBytes('\n')
-			if err != nil {
-				if err == io.EOF {
-					continue
-				}
-				log.Printf("Error reading stream: %v", err)
-				cancel()
-				return
-			}
-
-			// Skip empty lines
-			if len(bytes.TrimSpace(line)) == 0 {
-				continue
-			}
-
-			// Write the line to the response
-			if _, err := w.Write(line); err != nil {
-				log.Printf("Error writing to response: %v", err)
-				cancel()
-				return
-			}
-
-			// Flush the response writer
-			if f, ok := w.(http.Flusher); ok {
-				f.Flush()
-			} else {
-				log.Printf("Warning: ResponseWriter does not support Flush")
-			}
-		}
-	}
-}
-
-func handleRegularResponse(w http.ResponseWriter, resp *http.Response, originalModel string) {
-	log.Printf("Handling regular (non-streaming) response")
-	log.Printf("Response status: %d", resp.StatusCode)
-	log.Printf("Response headers: %+v", resp.Header)
-
-	// Read and log response body
-	body, err := readResponse(resp)
-	if err != nil {
-		log.Printf("Error reading response: %v", err)
-		http.Error(w, "Error reading response from upstream", http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Original response body: %s", string(body))
-
-	// Parse the DeepSeek response
-	var deepseekResp deepseek.Response
-
-	if err := json.Unmarshal(body, &deepseekResp); err != nil {
-		log.Printf("Error parsing DeepSeek response: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	// Convert to OpenAI format
-	openAIResp := openai.ChatCompletionResponse{
-		ID:      deepseekResp.ID,
-		Object:  "chat.completion",
-		Created: deepseekResp.Created,
-		Model:   originalModel,
-		Usage: openai.Usage{
-			PromptTokens:     deepseekResp.Usage.PromptTokens,
-			CompletionTokens: deepseekResp.Usage.CompletionTokens,
-			TotalTokens:      deepseekResp.Usage.TotalTokens,
-		},
-		Choices: convertResponseChoices(deepseekResp.Choices),
-	}
-
-	// Convert back to JSON
-	modifiedBody, err := json.Marshal(openAIResp)
-	if err != nil {
-		log.Printf("Error creating modified response: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Modified response body: %s", string(modifiedBody))
-
-	// Set response headers
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(resp.StatusCode)
-	w.Write(modifiedBody)
-	log.Printf("Modified response sent successfully")
-}
-
-func convertResponseChoices(choices []deepseek.Choice) []openai.Choice {
-	openaiChoices := make([]openai.Choice, len(choices))
-	for i, choice := range choices {
-		openaiChoices[i] = openai.Choice{
-			Index:        choice.Index,
-			Message:      convertResponseMessage(choice.Message),
-			FinishReason: choice.FinishReason,
-		}
-	}
-	return openaiChoices
-}
-
-func convertResponseMessage(message deepseek.Message) openai.Message {
-	return openai.Message{
-		Role: message.Role,
-		Content: openai.Content_String{
-			Content: message.Content,
-		},
-		ToolCalls:  convertResponseToolCalls(message.ToolCalls),
-		ToolCallID: message.ToolCallID,
-		Name:       message.Name,
-	}
-}
-
-func convertResponseToolCalls(toolCalls []deepseek.ToolCall) []openai.ToolCall {
-	openaiToolCalls := make([]openai.ToolCall, 0)
-	for i, tc := range toolCalls {
-		log.Printf("Tool call %d: %+v", i, tc)
-		// Ensure the tool call has the required fields
-		if tc.Function.Name == "" {
-			log.Printf("Warning: Empty function name in tool call %d", i)
-			continue
-		}
-		openaiToolCalls = append(openaiToolCalls, openai.ToolCall{
-			ID:   tc.ID,
-			Type: tc.Type,
-			Function: openai.ToolCallFunction{
-				Name:      tc.Function.Name,
-				Arguments: tc.Function.Arguments,
-			},
-		})
-	}
-	return openaiToolCalls
-}
-
-func copyHeaders(dst, src http.Header) {
-	// Headers to skip
-	skipHeaders := map[string]bool{
-		"Content-Length":    true,
-		"Content-Encoding":  true,
-		"Transfer-Encoding": true,
-		"Connection":        true,
-	}
-
-	for k, vv := range src {
-		if !skipHeaders[k] {
-			for _, v := range vv {
-				dst.Add(k, v)
-			}
-		}
-	}
-}
-
-func handleModelsRequest(w http.ResponseWriter) {
-	log.Printf("Handling models request")
-
-	// Get the requested model from the query parameters
-	response := openai.ModelsResponse{
-		Object: "list",
-		Data: []openai.Model{
-			{
-				ID:      deepseekChatModel,
-				Object:  "model",
-				Created: time.Now().Unix(),
-				OwnedBy: "deepseek",
-			},
-		},
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
-	log.Printf("Models response sent successfully")
-}
-
-func readResponse(resp *http.Response) ([]byte, error) {
-	var reader io.Reader = resp.Body
-
-	switch resp.Header.Get("Content-Encoding") {
-	case "gzip":
-		gzReader, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error creating gzip reader: %v", err)
-		}
-		defer gzReader.Close()
-		reader = gzReader
-	case "br":
-		reader = brotli.NewReader(resp.Body)
-	case "deflate":
-		reader = flate.NewReader(resp.Body)
-	}
-
-	return io.ReadAll(reader)
 }


### PR DESCRIPTION
**Description:**  
This pull request refactors the backend logic, moving each implementation into its own package and introducing an interface-based abstraction to facilitate testability and maintainability.

**Context:**  
Prior to this change, the backend implementations were tightly coupled with the main application code. This pull request addresses this issue by:

* Extracting the backend implementations (e.g., DeepSeek, OpenRouter, Ollama) into separate packages (`backend/deepseek`, etc.)
* Introducing a common `Backend` interface that each implementation must adhere to
* Allowing for easy mocking of these interfaces in future tests, making it easier to write robust and reliable test suites

By abstracting the backend implementations behind an interface, this change enables:

* Greater flexibility and modularity in the codebase
* Improved testability, as each backend can be tested independently without affecting other parts of the application
* Better maintainability, as changes to individual backends do not require modifying the main application code

This pull request sets the stage for future development and refinement of the cursor-deepseek project, ensuring that it remains scalable and adaptable to changing requirements.