### PR TITLE
Add Command Line Flag for Config File Location

### DIFF
--- a/internal/backend/ollama/ollama.go
+++ b/internal/backend/ollama/ollama.go
@@ -200,7 +200,7 @@ func handleStreamingResponse(ctx context.Context, w http.ResponseWriter, resp *h
 			return
 		}
 
-		lgr.Debugf(ctx, "data: %+v", string(data))
+		lgr.Tracef(ctx, "data: %+v", string(data))
 		fmt.Fprintf(w, "data: %s\n\n", data)
 		flusher.Flush()
 

--- a/internal/server/logger/logger.go
+++ b/internal/server/logger/logger.go
@@ -60,7 +60,7 @@ func (l *Logger) Trace(ctx context.Context, s string) {
 }
 
 func (l *Logger) Tracef(ctx context.Context, s string, args ...any) {
-	l.Info(ctx, fmt.Sprintf(s, args...))
+	l.Trace(ctx, fmt.Sprintf(s, args...))
 }
 
 func (l *Logger) Debug(ctx context.Context, s string) {

--- a/internal/server/middleware/logging.go
+++ b/internal/server/middleware/logging.go
@@ -9,6 +9,7 @@ import (
 
 type responseWriter struct {
 	http.ResponseWriter
+	http.Flusher
 	status        int
 	size          int
 	headerWritten bool
@@ -42,6 +43,7 @@ func withLogging(next http.Handler) http.Handler {
 		// Create wrapped response writer to capture status and size
 		wrapped := &responseWriter{
 			ResponseWriter: w,
+			Flusher:        w.(http.Flusher),
 			status:         http.StatusInternalServerError,
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,7 +95,7 @@ func (s *Server) Start() error {
 		return errors.Wrap(err, "error configuring HTTP/2")
 	}
 
-	logutils.FromContext(s.ctx).Infof(s.ctx, "Starting server on port %s", s.port)
+	logutils.FromContext(s.ctx).Infof(s.ctx, "Serving backend %s on port %s", s.backend.Name(), s.port)
 	return srv.ListenAndServe()
 }
 


### PR DESCRIPTION
This PR add a command line flag for the location of the config file. This is useful if the file is not co-located with the executable and called `config.yaml` as the code expects.